### PR TITLE
Ontology visualization: graph + table views with filters #9

### DIFF
--- a/.claude/hooks/pre-commit-viz.sh
+++ b/.claude/hooks/pre-commit-viz.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Pre-commit hook: regenerate ontology visualizations
+# Runs both viz scripts if their source data or scripts changed
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+# Check if any ontology or viz script files are staged
+CHANGED=$(git diff --cached --name-only | grep -E '(scripts/viz-ontology|ontology/data/|ontology/schema)')
+
+if [ -n "$CHANGED" ]; then
+    echo "🔄 Regenerating ontology visualizations..."
+
+    cd "$REPO_ROOT"
+
+    python3 scripts/viz-ontology.py 2>/dev/null
+    if [ $? -eq 0 ]; then
+        echo "  ✓ ontology-graph.html"
+    else
+        echo "  ✗ graph generation failed (pyvis not installed?)"
+    fi
+
+    python3 scripts/viz-ontology-table.py 2>/dev/null
+    if [ $? -eq 0 ]; then
+        echo "  ✓ ontology-table.html"
+    else
+        echo "  ✗ table generation failed"
+    fi
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 # Exported Google artifacts (may contain sensitive content)
-catalog/exports/
+catalog/exports/docs/
+catalog/exports/sheets/
+catalog/exports/slides/
+catalog/exports/pdf/
+# Viz outputs ARE committed (needed for viewing)
+!catalog/exports/viz/
 
 # RAG index data
 catalog/index/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,118 @@
+# AI-usage-lessons
+
+Personal knowledge management and course delivery system built on Claude Code.
+
+## What is this
+
+A system for managing:
+
+- A semester course **"Прикладные задачи ИИ"** (Applied AI Tasks) for МГТУ Баумана students
+- A project library of normative documents, references, and materials
+- All powered by **Claude Code as the only runtime** -- no separate backend, no custom UI
+
+Everything runs through subagents, skills, hooks, and MCP servers orchestrated by Claude Code.
+
+## Quick start
+
+1. Install [Claude Code](https://claude.ai/code)
+2. Clone this repo
+3. Run setup: see [`blueprint/setup.md`](blueprint/setup.md) for full instructions
+4. Configure MCP servers: workspace-mcp (Google), github-mcp, document-loader, local-rag, drawio, open-ontologies
+
+## Architecture
+
+```
+Google Drive  <-->  workspace-mcp  <-->  Claude Code  <-->  GitHub
+                                              |
+                document-loader --> local-rag (semantic search)
+                open-ontologies (knowledge graph)
+                drawio (diagrams)
+```
+
+## MCP Stack
+
+| Server | Package | Purpose |
+|--------|---------|---------|
+| workspace-mcp | `workspace-mcp` | Read/write Google Docs, Sheets, Slides, Drive |
+| document-loader | `awslabs.document-loader-mcp-server` | Read PDF, DOCX, XLSX, PPTX, images |
+| local-rag | `mcp-local-rag` | Semantic search over ingested documents |
+| drawio | `@drawio/mcp` | Generate/preview `.drawio` and Mermaid diagrams |
+| github | `github-mcp-server` | Issues, PRs, repo operations |
+| open-ontologies | `open-ontologies` | RDF/SPARQL + OWL reasoning + SHACL validation |
+
+## Skills (9)
+
+Skills live in `.claude/skills/` and are invoked via `/skill-name`.
+
+| Skill | Purpose |
+|-------|---------|
+| `sync-library` | Pull changes from Google Drive |
+| `catalog-docs` | Update document index and manifests |
+| `extract-links` | Extract and track cross-references |
+| `update-lecture` | Create/update lecture documents |
+| `build-deck` | Build/update Google Slides decks |
+| `diagram-refresh` | Regenerate diagrams from sources |
+| `issue-from-change` | Create GitHub Issues from detected changes |
+| `impact-check` | Analyze what changed and what it affects |
+| `reflect` | Post-session analysis and lessons learned |
+
+## Agents (5)
+
+Agent definitions live in `.claude/agents/`.
+
+| Agent | Responsibility |
+|-------|---------------|
+| `librarian` | Search, sync, export, index documents |
+| `course-curator` | Link normative docs, lectures, materials, assignments |
+| `doc-editor` | Edit Google Docs via workspace-mcp |
+| `deck-editor` | Build/update Google Slides, insert diagrams |
+| `issue-manager` | Create/triage GitHub Issues, track change queue |
+
+## Ontology visualization
+
+Graph and table views are available in [`catalog/exports/viz/`](catalog/exports/viz/).
+
+- `ontology-graph.html` -- interactive force-directed graph of entities and relations
+- `ontology-table.html` -- tabular view of all triples
+
+Regenerate with: `python3 scripts/viz-ontology.py`
+
+## Repository structure
+
+```
+blueprint/       -- portable agent setup for reproducing in new repos
+catalog/         -- exported Google artifacts, RAG index, manifests
+diagrams/        -- canonical .drawio files and exports
+library/         -- source materials: normative, lectures, materials
+models/          -- LanceDB embeddings and model data
+notes/           -- decisions, reflections, experiments
+ontology/        -- RDF schema (TTL), vocab, SPARQL queries
+scripts/         -- utility scripts (viz, export, etc.)
+templates/       -- reusable templates for lectures, slides, issues
+workflows/       -- routine descriptions, checklists, triage rules
+```
+
+See [`CLAUDE.md`](CLAUDE.md) for full conventions, rules, and detailed layout.
+
+## Course content
+
+- 14-lesson semester plan covering AI across 6 industries
+- Lecture 1 Google Doc: [Введение в прикладной ИИ](https://docs.google.com/document/d/1fJXhJMoSf-hRPGFnaTMB5z3rr0mJDs2iFaJBGIL36TE)
+- Lecture 1 Slides: [Slide deck](https://docs.google.com/presentation/d/12THMwFst0CHGJ0GJNqsWI1IMmF3jQMO3L2VszVEfJwI)
+- Semester roadmap diagram: [`diagrams/lecture-flows/semester-roadmap.drawio`](diagrams/lecture-flows/semester-roadmap.drawio)
+
+## Google Drive
+
+- [Working folder](https://drive.google.com/drive/folders/1-f2hpJrlUbfnMcxhR-6vF3xCsXZUI6am) -- active documents and materials
+- [Formal documents folder](https://drive.google.com/drive/folders/1fFxwUPu5V4dmCGMy5Y15xqzYF5CYD1yU) -- normative and reference materials
+
+## Documentation
+
+- [`CLAUDE.md`](CLAUDE.md) -- conventions, rules, MCP config, orchestration patterns
+- [`blueprint/`](blueprint/) -- portable agent setup for reproducing in new repos
+- [`notes/reflections/`](notes/reflections/) -- session analysis and lessons learned
+- [`notes/decisions.md`](notes/decisions.md) -- decision log and accumulated best practices
+
+## License
+
+Private repository.

--- a/README.md
+++ b/README.md
@@ -70,12 +70,23 @@ Agent definitions live in `.claude/agents/`.
 
 ## Ontology visualization
 
-Graph and table views are available in [`catalog/exports/viz/`](catalog/exports/viz/).
+Interactive views of the knowledge graph (documents, topics, lectures, and their relationships).
 
-- `ontology-graph.html` -- interactive force-directed graph of entities and relations
-- `ontology-table.html` -- tabular view of all triples
+**Open locally after cloning:**
+```bash
+python3 scripts/viz-ontology.py         # generate graph
+python3 scripts/viz-ontology-table.py   # generate table
+open catalog/exports/viz/index.html     # open combined viewer
+```
 
-Regenerate with: `python3 scripts/viz-ontology.py`
+**Views:**
+- [**Graph view**](catalog/exports/viz/ontology-graph.html) — force-directed graph with type filters, attribute panel, Drive/GitHub links, neighbor highlighting
+- [**Table view**](catalog/exports/viz/ontology-table.html) — sortable table with search, connected objects, clickable links
+- [**Combined viewer**](catalog/exports/viz/index.html) — tabbed interface with both views
+
+**Auto-regeneration:** a pre-commit hook runs the scripts automatically when ontology data or viz scripts change.
+
+**Scripts:** [`scripts/viz-ontology.py`](scripts/viz-ontology.py) | [`scripts/viz-ontology-table.py`](scripts/viz-ontology-table.py)
 
 ## Repository structure
 

--- a/catalog/exports/viz/README.md
+++ b/catalog/exports/viz/README.md
@@ -1,0 +1,48 @@
+# Ontology Visualization
+
+Interactive views of the AI-usage-lessons knowledge graph.
+
+## Views
+
+### [index.html](index.html) — Combined viewer
+Tabbed interface switching between graph and table views.
+
+### [ontology-graph.html](ontology-graph.html) — Graph View
+Interactive force-directed graph (pyvis/vis.js).
+
+**Features:**
+- Color-coded nodes by type (Document, Topic, Lecture, SlideDeck, Diagram)
+- Type filter toolbar — click to show only one type + its connections
+- Click node → right panel shows attributes, status, Drive/GitHub links
+- Neighbor highlighting — unrelated nodes fade out on selection
+- Drag, zoom, physics simulation
+
+### [ontology-table.html](ontology-table.html) — Table View
+Sortable entity table with connected objects.
+
+**Features:**
+- Type/Name/Status/Links/Connected Objects columns
+- Sort by clicking column headers
+- Search box filters by text
+- Type filter buttons (same as graph)
+- Click row → highlights connected rows
+- Connected object names are clickable (scrolls to that row)
+
+## Regeneration
+
+Views are auto-regenerated on every commit via pre-commit hook.
+
+Manual regeneration:
+```bash
+python3 scripts/viz-ontology.py                    # → ontology-graph.html
+python3 scripts/viz-ontology-table.py              # → ontology-table.html
+```
+
+## Data Source
+
+Generated from hardcoded node/edge data in the Python scripts. To update after ontology changes:
+1. Query ontology via `mcp__open-ontologies__onto_query`
+2. Update NODES and EDGES lists in both scripts
+3. Re-run scripts (or just commit — hook does it)
+
+Future: auto-read from `ontology/data/graph-*.ttl` files.

--- a/catalog/exports/viz/index.html
+++ b/catalog/exports/viz/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AI-usage-lessons — Ontology Views</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: 'Segoe UI', system-ui, sans-serif; background: #f5f5f5; color: #333; }
+  header { background: #2c3e50; color: #fff; padding: 20px 32px; }
+  header h1 { font-size: 22px; font-weight: 600; }
+  header p { font-size: 13px; color: #95a5a6; margin-top: 4px; }
+  .tabs { display: flex; gap: 0; background: #34495e; padding: 0 32px; }
+  .tab { padding: 12px 24px; color: #95a5a6; cursor: pointer; font-size: 14px; border-bottom: 3px solid transparent; transition: all 0.2s; }
+  .tab:hover { color: #ecf0f1; }
+  .tab.active { color: #fff; border-bottom-color: #3498db; }
+  .view { display: none; width: 100%; height: calc(100vh - 110px); }
+  .view.active { display: block; }
+  iframe { width: 100%; height: 100%; border: none; }
+  .links { padding: 12px 32px; background: #ecf0f1; font-size: 12px; }
+  .links a { color: #2980b9; margin-right: 16px; }
+</style>
+</head>
+<body>
+
+<header>
+  <h1>AI-usage-lessons — Ontology</h1>
+  <p>Knowledge graph: documents, topics, lectures, slides, diagrams and their relationships</p>
+</header>
+
+<div class="tabs">
+  <div class="tab active" onclick="switchView('graph')">Graph View</div>
+  <div class="tab" onclick="switchView('table')">Table View</div>
+</div>
+
+<div class="links">
+  <a href="https://github.com/tellina-study/AI-usage-lessons" target="_blank">GitHub Repo</a>
+  <a href="https://drive.google.com/drive/folders/1-f2hpJrlUbfnMcxhR-6vF3xCsXZUI6am" target="_blank">Google Drive</a>
+  <a href="https://github.com/orgs/tellina-study/projects/1/views/1" target="_blank">Project Board</a>
+</div>
+
+<div id="view-graph" class="view active">
+  <iframe src="ontology-graph.html"></iframe>
+</div>
+
+<div id="view-table" class="view">
+  <iframe src="ontology-table.html"></iframe>
+</div>
+
+<script>
+function switchView(name) {
+  document.querySelectorAll('.view').forEach(v => v.classList.remove('active'));
+  document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+  document.getElementById('view-' + name).classList.add('active');
+  event.target.classList.add('active');
+}
+</script>
+
+</body>
+</html>

--- a/catalog/exports/viz/ontology-graph.html
+++ b/catalog/exports/viz/ontology-graph.html
@@ -1,0 +1,368 @@
+<html>
+    <head>
+<style>
+  html, body { margin: 0; padding: 0; height: 100%; overflow: hidden; font-family: 'Segoe UI', sans-serif; }
+  #mynetwork { min-height: 600px;  position: absolute; left: 0; top: 0; right: 300px; bottom: 0; min-height: 600px; border-right: 1px solid #ddd; }
+  #panel { position: absolute; right: 0; top: 0; width: 300px; bottom: 0; overflow-y: auto; background: #fff; padding: 16px; box-sizing: border-box; }
+  #panel h3 { margin: 0 0 8px 0; color: #333; font-size: 16px; }
+  #panel .type-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; color: #fff; font-size: 11px; font-weight: bold; margin-bottom: 8px; }
+  #panel .attr { margin: 6px 0; font-size: 13px; }
+  #panel .attr-label { color: #888; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  #panel .attr-value { color: #333; word-break: break-all; }
+  #panel a { color: #4A90D9; text-decoration: none; }
+  #panel a:hover { text-decoration: underline; }
+  #panel .relations { margin-top: 12px; border-top: 1px solid #eee; padding-top: 8px; }
+  #panel .rel { margin: 4px 0; font-size: 12px; }
+  #panel .rel-arrow { color: #999; }
+  #panel .empty { color: #999; font-style: italic; padding: 40px 0; text-align: center; }
+  #legend { padding: 12px 0; border-bottom: 1px solid #eee; margin-bottom: 12px; font-size: 12px; }
+  #legend b { font-size: 13px; }
+  .leg-item { margin: 2px 0; }
+  .leg-dot { display: inline-block; width: 10px; height: 10px; border-radius: 50%; margin-right: 4px; vertical-align: middle; }
+  .leg-line { display: inline-block; width: 20px; height: 2px; margin-right: 4px; vertical-align: middle; }
+  #type-toolbar { position: fixed; top: 0; left: 0; right: 300px; height: 40px; background: #fff; border-bottom: 1px solid #ddd; display: flex; align-items: center; gap: 8px; padding: 0 16px; z-index: 10; box-sizing: border-box; }
+  #mynetwork { min-height: 600px;  top: 40px !important; }
+  .type-btn { border: none; padding: 5px 14px; border-radius: 20px; font-size: 12px; font-weight: 600; cursor: pointer; color: #fff; opacity: 0.7; transition: opacity 0.15s, box-shadow 0.15s; }
+  .type-btn:hover { opacity: 0.9; }
+  .type-btn.active { opacity: 1; box-shadow: 0 0 0 2px rgba(0,0,0,0.25); }
+</style>
+
+        <meta charset="utf-8">
+        
+            <script src="lib/bindings/utils.js"></script>
+            <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/vis-network/9.1.2/dist/dist/vis-network.min.css" integrity="sha512-WgxfT5LWjfszlPHXRmBWHkV2eceiWTOBvrKCNbdgDYTHrT2AeLCGbF4sZlZw3UMN3WtL0tGUoIAKsu8mllg/XA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+            <script src="https://cdnjs.cloudflare.com/ajax/libs/vis-network/9.1.2/dist/vis-network.min.js" integrity="sha512-LnvoEWDFrqGHlHmDD2101OrLcbsfkrzoSpvtSQtxK3RMnRV0eOkhhBN2dXHKRrUU8p2DGRTk35n4O8nWSVe1mQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+            
+        
+<center>
+<h1></h1>
+</center>
+
+<!-- <link rel="stylesheet" href="../node_modules/vis/dist/vis.min.css" type="text/css" />
+<script type="text/javascript" src="../node_modules/vis/dist/vis.js"> </script>-->
+        <link
+          href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css"
+          rel="stylesheet"
+          integrity="sha384-eOJMYsd53ii+scO/bJGFsiCZc+5NDVN2yr8+0RDqr0Ql0h+rP48ckxlpbzKgwra6"
+          crossorigin="anonymous"
+        />
+        <script
+          src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/js/bootstrap.bundle.min.js"
+          integrity="sha384-JEW9xMcG8R+pH31jmWH6WWP0WintQrMb4s7ZOdauHnUtxwoG2vI5DkLtS3qm9Ekf"
+          crossorigin="anonymous"
+        ></script>
+
+
+        <center>
+          <h1></h1>
+        </center>
+        <style type="text/css">
+
+             #mynetwork { min-height: 600px; 
+                 width: 100%;
+                 height: 100vh;
+                 background-color: #fafafa;
+                 border: 1px solid lightgray;
+                 position: relative;
+                 float: left;
+             }
+
+             
+
+             
+
+             
+        </style>
+    </head>
+
+
+    <body>
+        <div class="card" style="width: 100%">
+            
+            
+            <div id="mynetwork" class="card-body"></div>
+        </div>
+
+        
+        
+
+        <script type="text/javascript">
+
+              // initialize global variables.
+              var edges;
+              var nodes;
+              var allNodes;
+              var allEdges;
+              var nodeColors;
+              var originalNodes;
+              var network;
+              var container;
+              var options, data;
+              var filter = {
+                  item : '',
+                  property : '',
+                  value : []
+              };
+
+              
+
+              
+
+              // This method is responsible for drawing the graph, returns the drawn network
+              function drawGraph() {
+                  var container = document.getElementById('mynetwork');
+
+                  
+
+                  // parsing and collecting nodes and edges from the python
+                  nodes = new vis.DataSet([{"borderWidth": 2, "color": {"background": "#4A90D9", "border": "#4A90D9", "highlight": {"background": "#FFD700", "border": "#FF8C00"}}, "font": {"color": "#333"}, "id": "doc_v2", "label": "AI \u0432 \u0440\u0430\u0437\u043d\u044b\u0445 \u0438\u043d\u0434\u0443\u0441\u0442\u0440\u0438\u044f\u0445 (V2)", "shape": "dot", "size": 30}, {"borderWidth": 2, "color": {"background": "#4A90D9", "border": "#666", "highlight": {"background": "#FFD700", "border": "#FF8C00"}}, "font": {"color": "#333"}, "id": "doc_v1", "label": "AI \u0432 \u0446\u0438\u043a\u043b\u0435 \u0441\u043e\u0437\u0434\u0430\u043d\u0438\u044f \u041f\u041e (V1)", "shape": "dot", "size": 30}, {"borderWidth": 2, "color": {"background": "#4A90D9", "border": "#666", "highlight": {"background": "#FFD700", "border": "#FF8C00"}}, "font": {"color": "#333"}, "id": "doc_rpd_old", "label": "\u0420\u041f\u0414 (original)", "shape": "dot", "size": 30}, {"borderWidth": 2, "color": {"background": "#4A90D9", "border": "#4A90D9", "highlight": {"background": "#FFD700", "border": "#FF8C00"}}, "font": {"color": "#333"}, "id": "doc_rpd_new", "label": "\u0420\u041f\u0414 (updated)", "shape": "dot", "size": 30}, {"borderWidth": 2, "color": {"background": "#4A90D9", "border": "#4A90D9", "highlight": {"background": "#FFD700", "border": "#FF8C00"}}, "font": {"color": "#333"}, "id": "doc_fos", "label": "\u0424\u041e\u0421", "shape": "dot", "size": 30}, {"borderWidth": 2, "color": {"background": "#F5A623", "border": "#F5A623", "highlight": {"background": "#FFD700", "border": "#FF8C00"}}, "font": {"color": "#333"}, "id": "t_sw", "label": "AI \u0432 \u041f\u041e", "shape": "diamond", "size": 20}, {"borderWidth": 2, "color": {"background": "#F5A623", "border": "#F5A623", "highlight": {"background": "#FFD700", "border": "#FF8C00"}}, "font": {"color": "#333"}, "id": "t_fin", "label": "AI \u0432 \u0444\u0438\u043d\u0430\u043d\u0441\u0430\u0445", "shape": "diamond", "size": 20}, {"borderWidth": 2, "color": {"background": "#F5A623", "border": "#F5A623", "highlight": {"background": "#FFD700", "border": "#FF8C00"}}, "font": {"color": "#333"}, "id": "t_med", "label": "AI \u0432 \u043c\u0435\u0434\u0438\u0446\u0438\u043d\u0435", "shape": "diamond", "size": 20}, {"borderWidth": 2, "color": {"background": "#F5A623", "border": "#F5A623", "highlight": {"background": "#FFD700", "border": "#FF8C00"}}, "font": {"color": "#333"}, "id": "t_mfg", "label": "AI \u0432 \u043f\u0440\u043e\u0438\u0437\u0432\u043e\u0434\u0441\u0442\u0432\u0435", "shape": "diamond", "size": 20}, {"borderWidth": 2, "color": {"background": "#F5A623", "border": "#F5A623", "highlight": {"background": "#FFD700", "border": "#FF8C00"}}, "font": {"color": "#333"}, "id": "t_gov", "label": "AI \u0432 \u0433\u043e\u0441\u0443\u043f\u0440\u0430\u0432\u043b\u0435\u043d\u0438\u0438", "shape": "diamond", "size": 20}, {"borderWidth": 2, "color": {"background": "#F5A623", "border": "#F5A623", "highlight": {"background": "#FFD700", "border": "#FF8C00"}}, "font": {"color": "#333"}, "id": "t_cre", "label": "AI \u0432 \u043a\u0440\u0435\u0430\u0442\u0438\u0432\u0435", "shape": "diamond", "size": 20}, {"borderWidth": 2, "color": {"background": "#F5A623", "border": "#F5A623", "highlight": {"background": "#FFD700", "border": "#FF8C00"}}, "font": {"color": "#333"}, "id": "t_eth", "label": "\u042d\u0442\u0438\u043a\u0430 AI", "shape": "diamond", "size": 20}, {"borderWidth": 2, "color": {"background": "#F5A623", "border": "#F5A623", "highlight": {"background": "#FFD700", "border": "#FF8C00"}}, "font": {"color": "#333"}, "id": "t_prm", "label": "\u041f\u0440\u043e\u043c\u043f\u0442\u0438\u043d\u0433", "shape": "diamond", "size": 20}, {"borderWidth": 2, "color": {"background": "#F5A623", "border": "#F5A623", "highlight": {"background": "#FFD700", "border": "#FF8C00"}}, "font": {"color": "#333"}, "id": "t_rec", "label": "\u0420\u0435\u043a. \u0441\u0438\u0441\u0442\u0435\u043c\u044b", "shape": "diamond", "size": 20}, {"borderWidth": 2, "color": {"background": "#F5A623", "border": "#F5A623", "highlight": {"background": "#FFD700", "border": "#FF8C00"}}, "font": {"color": "#333"}, "id": "t_exp", "label": "\u042d\u043a\u0441\u043f. \u0441\u0438\u0441\u0442\u0435\u043c\u044b", "shape": "diamond", "size": 20}, {"borderWidth": 2, "color": {"background": "#7ED321", "border": "#7ED321", "highlight": {"background": "#FFD700", "border": "#FF8C00"}}, "font": {"color": "#333"}, "id": "lec_1", "label": "\u041b\u0435\u043a\u0446\u0438\u044f 1: \u0412\u0432\u0435\u0434\u0435\u043d\u0438\u0435", "shape": "box", "size": 25}, {"borderWidth": 2, "color": {"background": "#9B59B6", "border": "#9B59B6", "highlight": {"background": "#FFD700", "border": "#FF8C00"}}, "font": {"color": "#333"}, "id": "deck_1", "label": "\u0421\u043b\u0430\u0439\u0434\u044b \u041b1", "shape": "triangle", "size": 20}, {"borderWidth": 2, "color": {"background": "#9B59B6", "border": "#666", "highlight": {"background": "#FFD700", "border": "#FF8C00"}}, "font": {"color": "#333"}, "id": "deck_old", "label": "\u0418\u0418 \u0438 \u043c\u0438\u0440 (old)", "shape": "triangle", "size": 20}, {"borderWidth": 2, "color": {"background": "#1ABC9C", "border": "#1ABC9C", "highlight": {"background": "#FFD700", "border": "#FF8C00"}}, "font": {"color": "#333"}, "id": "diag_roadmap", "label": "\u0421\u0435\u043c\u0435\u0441\u0442\u0440\u043e\u0432\u044b\u0439 \u043f\u043b\u0430\u043d", "shape": "star", "size": 20}]);
+                  edges = new vis.DataSet([{"arrows": "to", "color": {"color": "#E74C3C", "highlight": "#FF8C00", "opacity": 0.8}, "font": {"color": "#E74C3C", "size": 9, "strokeWidth": 0}, "from": "doc_v2", "label": "supersedes", "smooth": {"roundness": 0.15, "type": "curvedCW"}, "to": "doc_v1", "width": 2}, {"arrows": "to", "color": {"color": "#E74C3C", "highlight": "#FF8C00", "opacity": 0.8}, "font": {"color": "#E74C3C", "size": 9, "strokeWidth": 0}, "from": "doc_rpd_new", "label": "supersedes", "smooth": {"roundness": 0.15, "type": "curvedCW"}, "to": "doc_rpd_old", "width": 2}, {"arrows": "to", "color": {"color": "#3498DB", "highlight": "#FF8C00", "opacity": 0.8}, "font": {"color": "#3498DB", "size": 9, "strokeWidth": 0}, "from": "doc_v2", "label": "depends_on", "smooth": {"roundness": 0.15, "type": "curvedCW"}, "to": "doc_rpd_new", "width": 2}, {"arrows": "to", "color": {"color": "#3498DB", "highlight": "#FF8C00", "opacity": 0.8}, "font": {"color": "#3498DB", "size": 9, "strokeWidth": 0}, "from": "doc_fos", "label": "depends_on", "smooth": {"roundness": 0.15, "type": "curvedCW"}, "to": "doc_rpd_old", "width": 2}, {"arrows": "to", "color": {"color": "#2ECC71", "highlight": "#FF8C00", "opacity": 0.8}, "font": {"color": "#2ECC71", "size": 9, "strokeWidth": 0}, "from": "doc_fos", "label": "cites", "smooth": {"roundness": 0.15, "type": "curvedCW"}, "to": "doc_rpd_old", "width": 2}, {"arrows": "to", "color": {"color": "#3498DB", "highlight": "#FF8C00", "opacity": 0.8}, "font": {"color": "#3498DB", "size": 9, "strokeWidth": 0}, "from": "deck_1", "label": "depends_on", "smooth": {"roundness": 0.15, "type": "curvedCW"}, "to": "lec_1", "width": 2}, {"arrows": "to", "color": {"color": "#1ABC9C", "highlight": "#FF8C00", "opacity": 0.8}, "font": {"color": "#1ABC9C", "size": 9, "strokeWidth": 0}, "from": "diag_roadmap", "label": "illustrates", "smooth": {"roundness": 0.15, "type": "curvedCW"}, "to": "doc_v2", "width": 2}, {"arrows": "to", "color": {"color": "#9B59B6", "highlight": "#FF8C00", "opacity": 0.8}, "font": {"color": "#9B59B6", "size": 9, "strokeWidth": 0}, "from": "doc_v2", "label": "belongs_to_topic", "smooth": {"roundness": 0.15, "type": "curvedCW"}, "to": "t_sw", "width": 2}, {"arrows": "to", "color": {"color": "#9B59B6", "highlight": "#FF8C00", "opacity": 0.8}, "font": {"color": "#9B59B6", "size": 9, "strokeWidth": 0}, "from": "doc_v2", "label": "belongs_to_topic", "smooth": {"roundness": 0.15, "type": "curvedCW"}, "to": "t_fin", "width": 2}, {"arrows": "to", "color": {"color": "#9B59B6", "highlight": "#FF8C00", "opacity": 0.8}, "font": {"color": "#9B59B6", "size": 9, "strokeWidth": 0}, "from": "doc_v2", "label": "belongs_to_topic", "smooth": {"roundness": 0.15, "type": "curvedCW"}, "to": "t_med", "width": 2}, {"arrows": "to", "color": {"color": "#9B59B6", "highlight": "#FF8C00", "opacity": 0.8}, "font": {"color": "#9B59B6", "size": 9, "strokeWidth": 0}, "from": "doc_v2", "label": "belongs_to_topic", "smooth": {"roundness": 0.15, "type": "curvedCW"}, "to": "t_mfg", "width": 2}, {"arrows": "to", "color": {"color": "#9B59B6", "highlight": "#FF8C00", "opacity": 0.8}, "font": {"color": "#9B59B6", "size": 9, "strokeWidth": 0}, "from": "doc_v2", "label": "belongs_to_topic", "smooth": {"roundness": 0.15, "type": "curvedCW"}, "to": "t_gov", "width": 2}, {"arrows": "to", "color": {"color": "#9B59B6", "highlight": "#FF8C00", "opacity": 0.8}, "font": {"color": "#9B59B6", "size": 9, "strokeWidth": 0}, "from": "doc_v2", "label": "belongs_to_topic", "smooth": {"roundness": 0.15, "type": "curvedCW"}, "to": "t_cre", "width": 2}, {"arrows": "to", "color": {"color": "#9B59B6", "highlight": "#FF8C00", "opacity": 0.8}, "font": {"color": "#9B59B6", "size": 9, "strokeWidth": 0}, "from": "doc_v2", "label": "belongs_to_topic", "smooth": {"roundness": 0.15, "type": "curvedCW"}, "to": "t_eth", "width": 2}, {"arrows": "to", "color": {"color": "#9B59B6", "highlight": "#FF8C00", "opacity": 0.8}, "font": {"color": "#9B59B6", "size": 9, "strokeWidth": 0}, "from": "doc_v2", "label": "belongs_to_topic", "smooth": {"roundness": 0.15, "type": "curvedCW"}, "to": "t_prm", "width": 2}, {"arrows": "to", "color": {"color": "#9B59B6", "highlight": "#FF8C00", "opacity": 0.8}, "font": {"color": "#9B59B6", "size": 9, "strokeWidth": 0}, "from": "doc_rpd_old", "label": "belongs_to_topic", "smooth": {"roundness": 0.15, "type": "curvedCW"}, "to": "t_rec", "width": 2}, {"arrows": "to", "color": {"color": "#9B59B6", "highlight": "#FF8C00", "opacity": 0.8}, "font": {"color": "#9B59B6", "size": 9, "strokeWidth": 0}, "from": "doc_rpd_old", "label": "belongs_to_topic", "smooth": {"roundness": 0.15, "type": "curvedCW"}, "to": "t_exp", "width": 2}, {"arrows": "to", "color": {"color": "#9B59B6", "highlight": "#FF8C00", "opacity": 0.8}, "font": {"color": "#9B59B6", "size": 9, "strokeWidth": 0}, "from": "doc_fos", "label": "belongs_to_topic", "smooth": {"roundness": 0.15, "type": "curvedCW"}, "to": "t_rec", "width": 2}, {"arrows": "to", "color": {"color": "#9B59B6", "highlight": "#FF8C00", "opacity": 0.8}, "font": {"color": "#9B59B6", "size": 9, "strokeWidth": 0}, "from": "doc_fos", "label": "belongs_to_topic", "smooth": {"roundness": 0.15, "type": "curvedCW"}, "to": "t_exp", "width": 2}, {"arrows": "to", "color": {"color": "#F39C12", "highlight": "#FF8C00", "opacity": 0.8}, "font": {"color": "#F39C12", "size": 9, "strokeWidth": 0}, "from": "lec_1", "label": "covers", "smooth": {"roundness": 0.15, "type": "curvedCW"}, "to": "t_sw", "width": 2}, {"arrows": "to", "color": {"color": "#F39C12", "highlight": "#FF8C00", "opacity": 0.8}, "font": {"color": "#F39C12", "size": 9, "strokeWidth": 0}, "from": "lec_1", "label": "covers", "smooth": {"roundness": 0.15, "type": "curvedCW"}, "to": "t_eth", "width": 2}, {"arrows": "to", "color": {"color": "#F39C12", "highlight": "#FF8C00", "opacity": 0.8}, "font": {"color": "#F39C12", "size": 9, "strokeWidth": 0}, "from": "lec_1", "label": "covers", "smooth": {"roundness": 0.15, "type": "curvedCW"}, "to": "t_prm", "width": 2}]);
+
+                  nodeColors = {};
+                  allNodes = nodes.get({ returnType: "Object" });
+                  for (nodeId in allNodes) {
+                    nodeColors[nodeId] = allNodes[nodeId].color;
+                  }
+                  allEdges = edges.get({ returnType: "Object" });
+                  // adding nodes and edges to the graph
+                  data = {nodes: nodes, edges: edges};
+
+                  var options = {"physics": {"barnesHut": {"gravitationalConstant": -4000, "springLength": 180, "damping": 0.5}}, "interaction": {"hover": true, "tooltipDelay": 100, "hideEdgesOnDrag": true, "multiselect": true, "navigationButtons": true}, "edges": {"smooth": {"type": "curvedCW", "roundness": 0.15}}};
+
+                  
+
+
+                  
+
+                  network = new vis.Network(container, data, options);
+
+                  
+
+                  
+
+                  
+
+
+                  
+
+                  return network;
+
+              }
+              drawGraph();
+        </script>
+    
+<div id="type-toolbar"><button class="type-btn active" data-type="All" style="background:#666" onclick="filterByType('All', this)">All</button><button class="type-btn" data-type="Document" style="background:#4A90D9" onclick="filterByType('Document', this)">Document</button><button class="type-btn" data-type="Topic" style="background:#F5A623" onclick="filterByType('Topic', this)">Topic</button><button class="type-btn" data-type="Lecture" style="background:#7ED321" onclick="filterByType('Lecture', this)">Lecture</button><button class="type-btn" data-type="SlideDeck" style="background:#9B59B6" onclick="filterByType('SlideDeck', this)">SlideDeck</button><button class="type-btn" data-type="Diagram" style="background:#1ABC9C" onclick="filterByType('Diagram', this)">Diagram</button></div>
+<div id="panel">
+  <div id="legend">
+    <b>Ontology Graph</b><br>
+    <div style="margin-top:6px"><b>Entities</b></div>
+    <div class="leg-item"><span class="leg-dot" style="background:#4A90D9"></span>Document</div>
+    <div class="leg-item"><span class="leg-dot" style="background:#F5A623"></span>Topic</div>
+    <div class="leg-item"><span class="leg-dot" style="background:#7ED321"></span>Lecture</div>
+    <div class="leg-item"><span class="leg-dot" style="background:#9B59B6"></span>SlideDeck</div>
+    <div class="leg-item"><span class="leg-dot" style="background:#1ABC9C"></span>Diagram</div>
+    <div style="margin-top:6px"><b>Relations</b></div>
+    <div class="leg-item"><span class="leg-line" style="background:#E74C3C"></span>supersedes</div>
+    <div class="leg-item"><span class="leg-line" style="background:#3498DB"></span>depends_on</div>
+    <div class="leg-item"><span class="leg-line" style="background:#2ECC71"></span>cites</div>
+    <div class="leg-item"><span class="leg-line" style="background:#9B59B6"></span>belongs_to_topic</div>
+    <div class="leg-item"><span class="leg-line" style="background:#F39C12"></span>covers</div>
+    <div class="leg-item"><span class="leg-line" style="background:#1ABC9C"></span>illustrates</div>
+  </div>
+  <div id="details">
+    <div class="empty">Click a node to see details</div>
+  </div>
+</div>
+
+<script>
+const NODE_DATA = {"doc_v2": {"label": "AI в разных индустриях (V2)", "type": "Document", "status": "active", "url": "https://docs.google.com/document/d/1k0ASel9hqLeBhtaDjS8k83Kpf640WFe8lln_MaV-OFY/edit", "local_path": "catalog/exports/docs/ai-v-raznyh-industriyah.md", "updated_at": "2026-03-06", "owner": "kzlevko@gmail.com"}, "doc_v1": {"label": "AI в цикле создания ПО (V1)", "type": "Document", "status": "archived", "url": "https://docs.google.com/document/d/1UliavdtqqZAyHu-JYDOGPFCbJZ44Enhju5TwmqV99Xg/edit", "local_path": "catalog/exports/docs/ai-v-tsikle-sozdaniya-po.md", "updated_at": "2026-02-23", "owner": "kzlevko@gmail.com"}, "doc_rpd_old": {"label": "РПД (original)", "type": "Document", "status": "archived", "url": "https://docs.google.com/document/d/18AFEqywR2utCu6a99zPuNa0MrIKYGmFd5ZWqKbu-6YE/edit", "local_path": "catalog/exports/docs/prog-otraslevoe-primenenie-AI.md", "updated_at": "2026-03-30", "owner": "kzlevko@gmail.com"}, "doc_rpd_new": {"label": "РПД (updated)", "type": "Document", "status": "active", "url": "https://docs.google.com/document/d/1zgAWfdyWlJBFMElmtKpmjgxySUCRccF9lNT-tj7J4fU/edit", "local_path": "catalog/exports/docs/prog-otraslevoe-updated-formal.md", "updated_at": "2026-03-31", "owner": "kzlevko@gmail.com"}, "doc_fos": {"label": "ФОС", "type": "Document", "status": "active", "url": "https://docs.google.com/document/d/1adJu0mKKIRgNHKRVNwVSdTI6sVdSykay/edit", "local_path": "catalog/exports/docs/fos_otraslevoe_primenenie_AI.docx", "updated_at": "2026-03-30", "owner": "kzlevko@gmail.com"}, "t_sw": {"label": "AI в ПО", "type": "Topic"}, "t_fin": {"label": "AI в финансах", "type": "Topic"}, "t_med": {"label": "AI в медицине", "type": "Topic"}, "t_mfg": {"label": "AI в производстве", "type": "Topic"}, "t_gov": {"label": "AI в госуправлении", "type": "Topic"}, "t_cre": {"label": "AI в креативе", "type": "Topic"}, "t_eth": {"label": "Этика AI", "type": "Topic"}, "t_prm": {"label": "Промптинг", "type": "Topic"}, "t_rec": {"label": "Рек. системы", "type": "Topic"}, "t_exp": {"label": "Эксп. системы", "type": "Topic"}, "lec_1": {"label": "Лекция 1: Введение", "type": "Lecture", "status": "draft", "url": "https://docs.google.com/document/d/1TsPeWdhgje3pj4yXMQrA9MDFb-hD9Ljed4hao7n-Ft8/edit", "updated_at": "2026-03-31"}, "deck_1": {"label": "Слайды Л1", "type": "SlideDeck", "status": "draft", "url": "https://docs.google.com/presentation/d/1BviVqnn7vtHGg09h22UzfUTyQswTHfvSXqol_JaRTyM/edit", "updated_at": "2026-03-31"}, "deck_old": {"label": "ИИ и мир (old)", "type": "SlideDeck", "status": "archived", "local_path": "catalog/exports/slides/ii-i-mir.pptx"}, "diag_roadmap": {"label": "Семестровый план", "type": "Diagram", "status": "active", "local_path": "diagrams/lecture-flows/semester-roadmap.drawio", "git_url": "https://github.com/tellina-study/AI-usage-lessons/blob/main/diagrams/lecture-flows/semester-roadmap.drawio"}};
+const EDGES = [{"source": "doc_v2", "target": "doc_v1", "relation": "supersedes"}, {"source": "doc_rpd_new", "target": "doc_rpd_old", "relation": "supersedes"}, {"source": "doc_v2", "target": "doc_rpd_new", "relation": "depends_on"}, {"source": "doc_fos", "target": "doc_rpd_old", "relation": "depends_on"}, {"source": "doc_fos", "target": "doc_rpd_old", "relation": "cites"}, {"source": "deck_1", "target": "lec_1", "relation": "depends_on"}, {"source": "diag_roadmap", "target": "doc_v2", "relation": "illustrates"}, {"source": "doc_v2", "target": "t_sw", "relation": "belongs_to_topic"}, {"source": "doc_v2", "target": "t_fin", "relation": "belongs_to_topic"}, {"source": "doc_v2", "target": "t_med", "relation": "belongs_to_topic"}, {"source": "doc_v2", "target": "t_mfg", "relation": "belongs_to_topic"}, {"source": "doc_v2", "target": "t_gov", "relation": "belongs_to_topic"}, {"source": "doc_v2", "target": "t_cre", "relation": "belongs_to_topic"}, {"source": "doc_v2", "target": "t_eth", "relation": "belongs_to_topic"}, {"source": "doc_v2", "target": "t_prm", "relation": "belongs_to_topic"}, {"source": "doc_rpd_old", "target": "t_rec", "relation": "belongs_to_topic"}, {"source": "doc_rpd_old", "target": "t_exp", "relation": "belongs_to_topic"}, {"source": "doc_fos", "target": "t_rec", "relation": "belongs_to_topic"}, {"source": "doc_fos", "target": "t_exp", "relation": "belongs_to_topic"}, {"source": "lec_1", "target": "t_sw", "relation": "covers"}, {"source": "lec_1", "target": "t_eth", "relation": "covers"}, {"source": "lec_1", "target": "t_prm", "relation": "covers"}];
+const TYPE_COLORS = {"Document": "#4A90D9", "Topic": "#F5A623", "Lecture": "#7ED321", "SlideDeck": "#9B59B6", "Diagram": "#1ABC9C", "Requirement": "#E74C3C", "Task": "#95A5A6", "Section": "#F39C12"};
+
+const REPO = "https://github.com/tellina-study/AI-usage-lessons/blob/main/";
+
+// Wait for vis network to initialize
+setTimeout(function() {
+  var network = Object.values(document.getElementById('mynetwork'))[0]
+    || window.network;
+
+  // Try to find the network instance
+  var frames = document.querySelectorAll('iframe');
+  if (!network) {
+    // pyvis stores network on the window of the iframe or directly
+    network = window.network;
+  }
+
+  if (!network) return;
+
+  var allNodes = null;
+  var allEdges = null;
+
+  try {
+    allNodes = network.body.data.nodes;
+    allEdges = network.body.data.edges;
+  } catch(e) {}
+
+  // Click handler — show attributes panel
+  network.on("click", function(params) {
+    var panel = document.getElementById("details");
+    if (params.nodes.length === 0) {
+      panel.innerHTML = '<div class="empty">Click a node to see details</div>';
+      resetHighlight();
+      return;
+    }
+
+    var nodeId = params.nodes[0];
+    var data = NODE_DATA[nodeId];
+    if (!data) {
+      panel.innerHTML = '<div class="empty">No data for ' + nodeId + '</div>';
+      return;
+    }
+
+    var color = TYPE_COLORS[data.type] || "#ccc";
+    var html = '<h3>' + data.label + '</h3>';
+    html += '<span class="type-badge" style="background:' + color + '">' + data.type + '</span>';
+
+    // Attributes
+    if (data.status) html += '<div class="attr"><div class="attr-label">Status</div><div class="attr-value">' + data.status + '</div></div>';
+    if (data.updated_at) html += '<div class="attr"><div class="attr-label">Updated</div><div class="attr-value">' + data.updated_at + '</div></div>';
+    if (data.owner) html += '<div class="attr"><div class="attr-label">Owner</div><div class="attr-value">' + data.owner + '</div></div>';
+
+    // Links
+    html += '<div class="attr" style="margin-top:12px"><div class="attr-label">Links</div></div>';
+    if (data.url) html += '<div class="attr"><a href="' + data.url + '" target="_blank">📄 Open in Google Drive</a></div>';
+    if (data.local_path) html += '<div class="attr"><a href="' + REPO + data.local_path + '" target="_blank">📁 View in GitHub</a></div>';
+    if (data.git_url) html += '<div class="attr"><a href="' + data.git_url + '" target="_blank">📁 View in GitHub</a></div>';
+
+    // Relations
+    html += '<div class="relations"><div class="attr-label">Relations</div>';
+    var outgoing = EDGES.filter(e => e.source === nodeId);
+    var incoming = EDGES.filter(e => e.target === nodeId);
+
+    outgoing.forEach(function(e) {
+      var targetData = NODE_DATA[e.target] || {label: e.target};
+      html += '<div class="rel"><span class="rel-arrow">→</span> <b>' + e.relation + '</b> ' + targetData.label + '</div>';
+    });
+    incoming.forEach(function(e) {
+      var sourceData = NODE_DATA[e.source] || {label: e.source};
+      html += '<div class="rel"><span class="rel-arrow">←</span> <b>' + e.relation + '</b> ' + sourceData.label + '</div>';
+    });
+    if (outgoing.length === 0 && incoming.length === 0) html += '<div class="rel" style="color:#999">No relations</div>';
+    html += '</div>';
+
+    panel.innerHTML = html;
+
+    // Highlight connected nodes
+    highlightNeighbors(nodeId);
+  });
+
+  function highlightNeighbors(nodeId) {
+    if (!allNodes || !allEdges) return;
+
+    var connectedNodes = new Set([nodeId]);
+    var connectedEdges = new Set();
+
+    allEdges.forEach(function(edge) {
+      var edgeData = allEdges.get(edge.id);
+      if (edgeData.from === nodeId || edgeData.to === nodeId) {
+        connectedNodes.add(edgeData.from);
+        connectedNodes.add(edgeData.to);
+        connectedEdges.add(edge.id);
+      }
+    });
+
+    // Dim non-connected nodes
+    var updates = [];
+    allNodes.forEach(function(node) {
+      if (connectedNodes.has(node.id)) {
+        updates.push({id: node.id, opacity: 1.0, font: {color: "#333"}});
+      } else {
+        updates.push({id: node.id, opacity: 0.15, font: {color: "#ccc"}});
+      }
+    });
+    allNodes.update(updates);
+
+    // Dim non-connected edges
+    var edgeUpdates = [];
+    allEdges.forEach(function(edge) {
+      if (connectedEdges.has(edge.id)) {
+        edgeUpdates.push({id: edge.id, hidden: false, width: 3});
+      } else {
+        edgeUpdates.push({id: edge.id, hidden: true});
+      }
+    });
+    allEdges.update(edgeUpdates);
+  }
+
+  function resetHighlight() {
+    if (!allNodes || !allEdges) return;
+    var updates = [];
+    allNodes.forEach(function(node) {
+      updates.push({id: node.id, hidden: false, opacity: 1.0, font: {color: "#333"}});
+    });
+    allNodes.update(updates);
+
+    var edgeUpdates = [];
+    allEdges.forEach(function(edge) {
+      edgeUpdates.push({id: edge.id, hidden: false, width: 2});
+    });
+    allEdges.update(edgeUpdates);
+  }
+
+  // Type filter logic — exposed globally so onclick can call it
+  window.filterByType = function(type, btnEl) {
+    // Update active button
+    document.querySelectorAll('.type-btn').forEach(function(b) { b.classList.remove('active'); });
+    if (btnEl) btnEl.classList.add('active');
+
+    if (!allNodes || !allEdges) return;
+
+    if (type === 'All') {
+      resetHighlight();
+      return;
+    }
+
+    // Find nodes of selected type
+    var selectedIds = new Set();
+    allNodes.forEach(function(node) {
+      if (NODE_DATA[node.id] && NODE_DATA[node.id].type === type) {
+        selectedIds.add(node.id);
+      }
+    });
+
+    // Find directly connected nodes (one hop)
+    var visibleIds = new Set(selectedIds);
+    allEdges.forEach(function(edge) {
+      var edgeData = allEdges.get(edge.id);
+      if (selectedIds.has(edgeData.from)) visibleIds.add(edgeData.to);
+      if (selectedIds.has(edgeData.to)) visibleIds.add(edgeData.from);
+    });
+
+    // Show/hide nodes
+    var nodeUpdates = [];
+    allNodes.forEach(function(node) {
+      if (visibleIds.has(node.id)) {
+        nodeUpdates.push({id: node.id, hidden: false, opacity: 1.0, font: {color: "#333"}});
+      } else {
+        nodeUpdates.push({id: node.id, hidden: true});
+      }
+    });
+    allNodes.update(nodeUpdates);
+
+    // Show edges only between visible nodes
+    var edgeUpdates = [];
+    allEdges.forEach(function(edge) {
+      var edgeData = allEdges.get(edge.id);
+      if (visibleIds.has(edgeData.from) && visibleIds.has(edgeData.to)) {
+        edgeUpdates.push({id: edge.id, hidden: false, width: 2});
+      } else {
+        edgeUpdates.push({id: edge.id, hidden: true});
+      }
+    });
+    allEdges.update(edgeUpdates);
+  };
+
+}, 1000);
+</script>
+</body>
+</html>

--- a/catalog/exports/viz/ontology-table.html
+++ b/catalog/exports/viz/ontology-table.html
@@ -1,0 +1,395 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Ontology Table</title>
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+  font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+  background: #f5f6fa;
+  color: #333;
+  padding: 20px;
+  min-height: 100vh;
+}
+h1 {
+  font-size: 22px;
+  margin-bottom: 16px;
+  color: #2c3e50;
+}
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 12px;
+}
+.filter-btn {
+  padding: 5px 14px;
+  border: 2px solid #ddd;
+  border-radius: 20px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  color: #555;
+  transition: all 0.15s;
+}
+.filter-btn:hover {
+  border-color: #aaa;
+  background: #f0f0f0;
+}
+.filter-btn.active {
+  border-color: var(--btn-color, #4A90D9);
+  background: var(--btn-color, #4A90D9);
+  color: #fff;
+}
+.search-box {
+  margin-bottom: 12px;
+}
+.search-box input {
+  width: 100%;
+  max-width: 400px;
+  padding: 8px 14px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 14px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+.search-box input:focus {
+  border-color: #4A90D9;
+  box-shadow: 0 0 0 2px rgba(74,144,217,0.15);
+}
+.table-wrap {
+  overflow-x: auto;
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  font-size: 14px;
+}
+thead th {
+  background: #2c3e50;
+  color: #fff;
+  padding: 10px 14px;
+  text-align: left;
+  font-weight: 600;
+  font-size: 13px;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}
+thead th:hover {
+  background: #34495e;
+}
+thead th .sort-arrow {
+  margin-left: 4px;
+  font-size: 10px;
+  opacity: 0.5;
+}
+thead th.sorted .sort-arrow {
+  opacity: 1;
+}
+tbody tr {
+  transition: background 0.1s;
+}
+tbody tr:nth-child(even) {
+  background: #fafbfc;
+}
+tbody tr:hover {
+  background: #eef3f9;
+}
+tbody tr.highlighted {
+  background: #fff9e6 !important;
+}
+tbody tr.connected-highlight {
+  background: #f0f7ff !important;
+}
+tbody tr.hidden-row {
+  display: none;
+}
+td {
+  padding: 8px 14px;
+  border-bottom: 1px solid #eee;
+  vertical-align: top;
+}
+.type-badge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 12px;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.status-badge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 12px;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.name-cell {
+  font-weight: 500;
+  min-width: 180px;
+}
+.link-badge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 500;
+  text-decoration: none;
+  margin-right: 4px;
+}
+.link-drive {
+  background: #e8f0fe;
+  color: #1a73e8;
+}
+.link-drive:hover {
+  background: #d2e3fc;
+}
+.link-github {
+  background: #f0f0f0;
+  color: #333;
+}
+.link-github:hover {
+  background: #e0e0e0;
+}
+.no-links {
+  color: #ccc;
+  font-size: 13px;
+}
+.conn-cell {
+  font-size: 13px;
+  line-height: 1.6;
+  min-width: 250px;
+}
+.conn-item b {
+  color: #666;
+  font-weight: 500;
+}
+.conn-link {
+  color: #4A90D9;
+  text-decoration: none;
+  cursor: pointer;
+}
+.conn-link:hover {
+  text-decoration: underline;
+}
+.count-info {
+  margin-bottom: 8px;
+  font-size: 13px;
+  color: #888;
+}
+@media (max-width: 768px) {
+  body { padding: 10px; }
+  td, thead th { padding: 6px 8px; font-size: 13px; }
+  .name-cell { min-width: 120px; }
+  .conn-cell { min-width: 180px; }
+}
+</style>
+</head>
+<body>
+
+<h1>Ontology Table</h1>
+
+<div class="toolbar">
+<button class="filter-btn active" data-filter="All">All</button>
+<button class="filter-btn" data-filter="Diagram" style="--btn-color:#1ABC9C">Diagram</button>
+<button class="filter-btn" data-filter="Document" style="--btn-color:#4A90D9">Document</button>
+<button class="filter-btn" data-filter="Lecture" style="--btn-color:#7ED321">Lecture</button>
+<button class="filter-btn" data-filter="SlideDeck" style="--btn-color:#9B59B6">SlideDeck</button>
+<button class="filter-btn" data-filter="Topic" style="--btn-color:#F5A623">Topic</button>
+</div>
+
+<div class="search-box">
+  <input type="text" id="search-input" placeholder="Search by name, type, status...">
+</div>
+
+<div class="count-info">Showing <span id="visible-count">19</span> of 19 entities</div>
+
+<div class="table-wrap">
+<table id="onto-table">
+<thead>
+<tr>
+  <th data-col="type">Type <span class="sort-arrow">&#9650;&#9660;</span></th>
+  <th data-col="name">Name <span class="sort-arrow">&#9650;&#9660;</span></th>
+  <th data-col="status">Status <span class="sort-arrow">&#9650;&#9660;</span></th>
+  <th>Links</th>
+  <th>Connected Objects</th>
+</tr>
+</thead>
+<tbody>
+<tr id="doc_v2" class="onto-row" data-type="Document" data-name="AI в разных индустриях (V2)" data-status="active" data-id="doc_v2"><td><span class="type-badge" style="background:#4A90D9">Document</span></td><td class="name-cell">AI в разных индустриях (V2)</td><td><span class="status-badge" style="background:#27ae60">active</span></td><td><a href="https://docs.google.com/document/d/1k0ASel9hqLeBhtaDjS8k83Kpf640WFe8lln_MaV-OFY/edit" target="_blank" class="link-badge link-drive">Drive</a> <a href="https://github.com/tellina-study/AI-usage-lessons/blob/main/catalog/exports/docs/ai-v-raznyh-industriyah.md" target="_blank" class="link-badge link-github">GitHub</a></td><td class="conn-cell"><span class="conn-item">&rarr; <b>supersedes</b>: <a href="#doc_v1" class="conn-link" data-target="doc_v1">AI в цикле создания ПО (V1)</a></span><br><span class="conn-item">&rarr; <b>depends_on</b>: <a href="#doc_rpd_new" class="conn-link" data-target="doc_rpd_new">РПД (updated)</a></span><br><span class="conn-item">&larr; <b>illustrates</b>: <a href="#diag_roadmap" class="conn-link" data-target="diag_roadmap">Семестровый план</a></span><br><span class="conn-item">&rarr; <b>belongs_to_topic</b>: <a href="#t_sw" class="conn-link" data-target="t_sw">AI в ПО</a></span><br><span class="conn-item">&rarr; <b>belongs_to_topic</b>: <a href="#t_fin" class="conn-link" data-target="t_fin">AI в финансах</a></span><br><span class="conn-item">&rarr; <b>belongs_to_topic</b>: <a href="#t_med" class="conn-link" data-target="t_med">AI в медицине</a></span><br><span class="conn-item">&rarr; <b>belongs_to_topic</b>: <a href="#t_mfg" class="conn-link" data-target="t_mfg">AI в производстве</a></span><br><span class="conn-item">&rarr; <b>belongs_to_topic</b>: <a href="#t_gov" class="conn-link" data-target="t_gov">AI в госуправлении</a></span><br><span class="conn-item">&rarr; <b>belongs_to_topic</b>: <a href="#t_cre" class="conn-link" data-target="t_cre">AI в креативе</a></span><br><span class="conn-item">&rarr; <b>belongs_to_topic</b>: <a href="#t_eth" class="conn-link" data-target="t_eth">Этика AI</a></span><br><span class="conn-item">&rarr; <b>belongs_to_topic</b>: <a href="#t_prm" class="conn-link" data-target="t_prm">Промптинг</a></span></td></tr>
+<tr id="doc_v1" class="onto-row" data-type="Document" data-name="AI в цикле создания ПО (V1)" data-status="archived" data-id="doc_v1"><td><span class="type-badge" style="background:#4A90D9">Document</span></td><td class="name-cell">AI в цикле создания ПО (V1)</td><td><span class="status-badge" style="background:#95a5a6">archived</span></td><td><a href="https://docs.google.com/document/d/1UliavdtqqZAyHu-JYDOGPFCbJZ44Enhju5TwmqV99Xg/edit" target="_blank" class="link-badge link-drive">Drive</a> <a href="https://github.com/tellina-study/AI-usage-lessons/blob/main/catalog/exports/docs/ai-v-tsikle-sozdaniya-po.md" target="_blank" class="link-badge link-github">GitHub</a></td><td class="conn-cell"><span class="conn-item">&larr; <b>supersedes</b>: <a href="#doc_v2" class="conn-link" data-target="doc_v2">AI в разных индустриях (V2)</a></span></td></tr>
+<tr id="doc_rpd_old" class="onto-row" data-type="Document" data-name="РПД (original)" data-status="archived" data-id="doc_rpd_old"><td><span class="type-badge" style="background:#4A90D9">Document</span></td><td class="name-cell">РПД (original)</td><td><span class="status-badge" style="background:#95a5a6">archived</span></td><td><a href="https://docs.google.com/document/d/18AFEqywR2utCu6a99zPuNa0MrIKYGmFd5ZWqKbu-6YE/edit" target="_blank" class="link-badge link-drive">Drive</a> <a href="https://github.com/tellina-study/AI-usage-lessons/blob/main/catalog/exports/docs/prog-otraslevoe-primenenie-AI.md" target="_blank" class="link-badge link-github">GitHub</a></td><td class="conn-cell"><span class="conn-item">&larr; <b>supersedes</b>: <a href="#doc_rpd_new" class="conn-link" data-target="doc_rpd_new">РПД (updated)</a></span><br><span class="conn-item">&larr; <b>depends_on</b>: <a href="#doc_fos" class="conn-link" data-target="doc_fos">ФОС</a></span><br><span class="conn-item">&larr; <b>cites</b>: <a href="#doc_fos" class="conn-link" data-target="doc_fos">ФОС</a></span><br><span class="conn-item">&rarr; <b>belongs_to_topic</b>: <a href="#t_rec" class="conn-link" data-target="t_rec">Рек. системы</a></span><br><span class="conn-item">&rarr; <b>belongs_to_topic</b>: <a href="#t_exp" class="conn-link" data-target="t_exp">Эксп. системы</a></span></td></tr>
+<tr id="doc_rpd_new" class="onto-row" data-type="Document" data-name="РПД (updated)" data-status="active" data-id="doc_rpd_new"><td><span class="type-badge" style="background:#4A90D9">Document</span></td><td class="name-cell">РПД (updated)</td><td><span class="status-badge" style="background:#27ae60">active</span></td><td><a href="https://docs.google.com/document/d/1zgAWfdyWlJBFMElmtKpmjgxySUCRccF9lNT-tj7J4fU/edit" target="_blank" class="link-badge link-drive">Drive</a> <a href="https://github.com/tellina-study/AI-usage-lessons/blob/main/catalog/exports/docs/prog-otraslevoe-updated-formal.md" target="_blank" class="link-badge link-github">GitHub</a></td><td class="conn-cell"><span class="conn-item">&rarr; <b>supersedes</b>: <a href="#doc_rpd_old" class="conn-link" data-target="doc_rpd_old">РПД (original)</a></span><br><span class="conn-item">&larr; <b>depends_on</b>: <a href="#doc_v2" class="conn-link" data-target="doc_v2">AI в разных индустриях (V2)</a></span></td></tr>
+<tr id="doc_fos" class="onto-row" data-type="Document" data-name="ФОС" data-status="active" data-id="doc_fos"><td><span class="type-badge" style="background:#4A90D9">Document</span></td><td class="name-cell">ФОС</td><td><span class="status-badge" style="background:#27ae60">active</span></td><td><a href="https://docs.google.com/document/d/1adJu0mKKIRgNHKRVNwVSdTI6sVdSykay/edit" target="_blank" class="link-badge link-drive">Drive</a> <a href="https://github.com/tellina-study/AI-usage-lessons/blob/main/catalog/exports/docs/fos_otraslevoe_primenenie_AI.docx" target="_blank" class="link-badge link-github">GitHub</a></td><td class="conn-cell"><span class="conn-item">&rarr; <b>depends_on</b>: <a href="#doc_rpd_old" class="conn-link" data-target="doc_rpd_old">РПД (original)</a></span><br><span class="conn-item">&rarr; <b>cites</b>: <a href="#doc_rpd_old" class="conn-link" data-target="doc_rpd_old">РПД (original)</a></span><br><span class="conn-item">&rarr; <b>belongs_to_topic</b>: <a href="#t_rec" class="conn-link" data-target="t_rec">Рек. системы</a></span><br><span class="conn-item">&rarr; <b>belongs_to_topic</b>: <a href="#t_exp" class="conn-link" data-target="t_exp">Эксп. системы</a></span></td></tr>
+<tr id="t_sw" class="onto-row" data-type="Topic" data-name="AI в ПО" data-status="" data-id="t_sw"><td><span class="type-badge" style="background:#F5A623">Topic</span></td><td class="name-cell">AI в ПО</td><td><span class="no-links">--</span></td><td><span class="no-links">--</span></td><td class="conn-cell"><span class="conn-item">&larr; <b>belongs_to_topic</b>: <a href="#doc_v2" class="conn-link" data-target="doc_v2">AI в разных индустриях (V2)</a></span><br><span class="conn-item">&larr; <b>covers</b>: <a href="#lec_1" class="conn-link" data-target="lec_1">Лекция 1: Введение</a></span></td></tr>
+<tr id="t_fin" class="onto-row" data-type="Topic" data-name="AI в финансах" data-status="" data-id="t_fin"><td><span class="type-badge" style="background:#F5A623">Topic</span></td><td class="name-cell">AI в финансах</td><td><span class="no-links">--</span></td><td><span class="no-links">--</span></td><td class="conn-cell"><span class="conn-item">&larr; <b>belongs_to_topic</b>: <a href="#doc_v2" class="conn-link" data-target="doc_v2">AI в разных индустриях (V2)</a></span></td></tr>
+<tr id="t_med" class="onto-row" data-type="Topic" data-name="AI в медицине" data-status="" data-id="t_med"><td><span class="type-badge" style="background:#F5A623">Topic</span></td><td class="name-cell">AI в медицине</td><td><span class="no-links">--</span></td><td><span class="no-links">--</span></td><td class="conn-cell"><span class="conn-item">&larr; <b>belongs_to_topic</b>: <a href="#doc_v2" class="conn-link" data-target="doc_v2">AI в разных индустриях (V2)</a></span></td></tr>
+<tr id="t_mfg" class="onto-row" data-type="Topic" data-name="AI в производстве" data-status="" data-id="t_mfg"><td><span class="type-badge" style="background:#F5A623">Topic</span></td><td class="name-cell">AI в производстве</td><td><span class="no-links">--</span></td><td><span class="no-links">--</span></td><td class="conn-cell"><span class="conn-item">&larr; <b>belongs_to_topic</b>: <a href="#doc_v2" class="conn-link" data-target="doc_v2">AI в разных индустриях (V2)</a></span></td></tr>
+<tr id="t_gov" class="onto-row" data-type="Topic" data-name="AI в госуправлении" data-status="" data-id="t_gov"><td><span class="type-badge" style="background:#F5A623">Topic</span></td><td class="name-cell">AI в госуправлении</td><td><span class="no-links">--</span></td><td><span class="no-links">--</span></td><td class="conn-cell"><span class="conn-item">&larr; <b>belongs_to_topic</b>: <a href="#doc_v2" class="conn-link" data-target="doc_v2">AI в разных индустриях (V2)</a></span></td></tr>
+<tr id="t_cre" class="onto-row" data-type="Topic" data-name="AI в креативе" data-status="" data-id="t_cre"><td><span class="type-badge" style="background:#F5A623">Topic</span></td><td class="name-cell">AI в креативе</td><td><span class="no-links">--</span></td><td><span class="no-links">--</span></td><td class="conn-cell"><span class="conn-item">&larr; <b>belongs_to_topic</b>: <a href="#doc_v2" class="conn-link" data-target="doc_v2">AI в разных индустриях (V2)</a></span></td></tr>
+<tr id="t_eth" class="onto-row" data-type="Topic" data-name="Этика AI" data-status="" data-id="t_eth"><td><span class="type-badge" style="background:#F5A623">Topic</span></td><td class="name-cell">Этика AI</td><td><span class="no-links">--</span></td><td><span class="no-links">--</span></td><td class="conn-cell"><span class="conn-item">&larr; <b>belongs_to_topic</b>: <a href="#doc_v2" class="conn-link" data-target="doc_v2">AI в разных индустриях (V2)</a></span><br><span class="conn-item">&larr; <b>covers</b>: <a href="#lec_1" class="conn-link" data-target="lec_1">Лекция 1: Введение</a></span></td></tr>
+<tr id="t_prm" class="onto-row" data-type="Topic" data-name="Промптинг" data-status="" data-id="t_prm"><td><span class="type-badge" style="background:#F5A623">Topic</span></td><td class="name-cell">Промптинг</td><td><span class="no-links">--</span></td><td><span class="no-links">--</span></td><td class="conn-cell"><span class="conn-item">&larr; <b>belongs_to_topic</b>: <a href="#doc_v2" class="conn-link" data-target="doc_v2">AI в разных индустриях (V2)</a></span><br><span class="conn-item">&larr; <b>covers</b>: <a href="#lec_1" class="conn-link" data-target="lec_1">Лекция 1: Введение</a></span></td></tr>
+<tr id="t_rec" class="onto-row" data-type="Topic" data-name="Рек. системы" data-status="" data-id="t_rec"><td><span class="type-badge" style="background:#F5A623">Topic</span></td><td class="name-cell">Рек. системы</td><td><span class="no-links">--</span></td><td><span class="no-links">--</span></td><td class="conn-cell"><span class="conn-item">&larr; <b>belongs_to_topic</b>: <a href="#doc_rpd_old" class="conn-link" data-target="doc_rpd_old">РПД (original)</a></span><br><span class="conn-item">&larr; <b>belongs_to_topic</b>: <a href="#doc_fos" class="conn-link" data-target="doc_fos">ФОС</a></span></td></tr>
+<tr id="t_exp" class="onto-row" data-type="Topic" data-name="Эксп. системы" data-status="" data-id="t_exp"><td><span class="type-badge" style="background:#F5A623">Topic</span></td><td class="name-cell">Эксп. системы</td><td><span class="no-links">--</span></td><td><span class="no-links">--</span></td><td class="conn-cell"><span class="conn-item">&larr; <b>belongs_to_topic</b>: <a href="#doc_rpd_old" class="conn-link" data-target="doc_rpd_old">РПД (original)</a></span><br><span class="conn-item">&larr; <b>belongs_to_topic</b>: <a href="#doc_fos" class="conn-link" data-target="doc_fos">ФОС</a></span></td></tr>
+<tr id="lec_1" class="onto-row" data-type="Lecture" data-name="Лекция 1: Введение" data-status="draft" data-id="lec_1"><td><span class="type-badge" style="background:#7ED321">Lecture</span></td><td class="name-cell">Лекция 1: Введение</td><td><span class="status-badge" style="background:#f1c40f">draft</span></td><td><a href="https://docs.google.com/document/d/1TsPeWdhgje3pj4yXMQrA9MDFb-hD9Ljed4hao7n-Ft8/edit" target="_blank" class="link-badge link-drive">Drive</a></td><td class="conn-cell"><span class="conn-item">&larr; <b>depends_on</b>: <a href="#deck_1" class="conn-link" data-target="deck_1">Слайды Л1</a></span><br><span class="conn-item">&rarr; <b>covers</b>: <a href="#t_sw" class="conn-link" data-target="t_sw">AI в ПО</a></span><br><span class="conn-item">&rarr; <b>covers</b>: <a href="#t_eth" class="conn-link" data-target="t_eth">Этика AI</a></span><br><span class="conn-item">&rarr; <b>covers</b>: <a href="#t_prm" class="conn-link" data-target="t_prm">Промптинг</a></span></td></tr>
+<tr id="deck_1" class="onto-row" data-type="SlideDeck" data-name="Слайды Л1" data-status="draft" data-id="deck_1"><td><span class="type-badge" style="background:#9B59B6">SlideDeck</span></td><td class="name-cell">Слайды Л1</td><td><span class="status-badge" style="background:#f1c40f">draft</span></td><td><a href="https://docs.google.com/presentation/d/1BviVqnn7vtHGg09h22UzfUTyQswTHfvSXqol_JaRTyM/edit" target="_blank" class="link-badge link-drive">Drive</a></td><td class="conn-cell"><span class="conn-item">&rarr; <b>depends_on</b>: <a href="#lec_1" class="conn-link" data-target="lec_1">Лекция 1: Введение</a></span></td></tr>
+<tr id="deck_old" class="onto-row" data-type="SlideDeck" data-name="ИИ и мир (old)" data-status="archived" data-id="deck_old"><td><span class="type-badge" style="background:#9B59B6">SlideDeck</span></td><td class="name-cell">ИИ и мир (old)</td><td><span class="status-badge" style="background:#95a5a6">archived</span></td><td><a href="https://github.com/tellina-study/AI-usage-lessons/blob/main/catalog/exports/slides/ii-i-mir.pptx" target="_blank" class="link-badge link-github">GitHub</a></td><td class="conn-cell"><span class="no-links">--</span></td></tr>
+<tr id="diag_roadmap" class="onto-row" data-type="Diagram" data-name="Семестровый план" data-status="active" data-id="diag_roadmap"><td><span class="type-badge" style="background:#1ABC9C">Diagram</span></td><td class="name-cell">Семестровый план</td><td><span class="status-badge" style="background:#27ae60">active</span></td><td><a href="https://github.com/tellina-study/AI-usage-lessons/blob/main/diagrams/lecture-flows/semester-roadmap.drawio" target="_blank" class="link-badge link-github">GitHub</a></td><td class="conn-cell"><span class="conn-item">&rarr; <b>illustrates</b>: <a href="#doc_v2" class="conn-link" data-target="doc_v2">AI в разных индустриях (V2)</a></span></td></tr>
+</tbody>
+</table>
+</div>
+
+<script>
+(function() {
+  const CONN_MAP = {"doc_v2": ["doc_rpd_new", "doc_v1", "diag_roadmap", "t_mfg", "t_eth", "t_gov", "t_cre", "t_fin", "t_med", "t_sw", "t_prm"], "doc_v1": ["doc_v2"], "doc_rpd_old": ["doc_rpd_new", "t_rec", "doc_fos", "t_exp"], "doc_rpd_new": ["doc_rpd_old", "doc_v2"], "doc_fos": ["doc_rpd_old", "t_rec", "t_exp"], "t_sw": ["lec_1", "doc_v2"], "t_fin": ["doc_v2"], "t_med": ["doc_v2"], "t_mfg": ["doc_v2"], "t_gov": ["doc_v2"], "t_cre": ["doc_v2"], "t_eth": ["lec_1", "doc_v2"], "t_prm": ["lec_1", "doc_v2"], "t_rec": ["doc_rpd_old", "doc_fos"], "t_exp": ["doc_rpd_old", "doc_fos"], "lec_1": ["t_prm", "deck_1", "t_sw", "t_eth"], "deck_1": ["lec_1"], "deck_old": [], "diag_roadmap": ["doc_v2"]};
+
+  // --- Sorting ---
+  const table = document.getElementById('onto-table');
+  const thead = table.querySelector('thead');
+  const tbody = table.querySelector('tbody');
+  let sortCol = null;
+  let sortAsc = true;
+
+  thead.querySelectorAll('th[data-col]').forEach(function(th) {
+    th.addEventListener('click', function() {
+      const col = th.getAttribute('data-col');
+      if (sortCol === col) {
+        sortAsc = !sortAsc;
+      } else {
+        sortCol = col;
+        sortAsc = true;
+      }
+
+      // Update header styles
+      thead.querySelectorAll('th').forEach(function(h) { h.classList.remove('sorted'); });
+      th.classList.add('sorted');
+
+      const rows = Array.from(tbody.querySelectorAll('tr.onto-row'));
+      rows.sort(function(a, b) {
+        let va = a.getAttribute('data-' + col) || '';
+        let vb = b.getAttribute('data-' + col) || '';
+        va = va.toLowerCase();
+        vb = vb.toLowerCase();
+        if (va < vb) return sortAsc ? -1 : 1;
+        if (va > vb) return sortAsc ? 1 : -1;
+        return 0;
+      });
+
+      rows.forEach(function(row) { tbody.appendChild(row); });
+    });
+  });
+
+  // --- Filtering by type ---
+  let activeFilter = 'All';
+  const filterBtns = document.querySelectorAll('.filter-btn');
+
+  filterBtns.forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      filterBtns.forEach(function(b) { b.classList.remove('active'); });
+      btn.classList.add('active');
+      activeFilter = btn.getAttribute('data-filter');
+      applyFilters();
+    });
+  });
+
+  // --- Search ---
+  const searchInput = document.getElementById('search-input');
+  searchInput.addEventListener('input', function() {
+    applyFilters();
+  });
+
+  function applyFilters() {
+    const query = searchInput.value.toLowerCase().trim();
+    const rows = tbody.querySelectorAll('tr.onto-row');
+    let visible = 0;
+
+    rows.forEach(function(row) {
+      const type = row.getAttribute('data-type');
+      const name = row.getAttribute('data-name').toLowerCase();
+      const status = row.getAttribute('data-status').toLowerCase();
+      const text = name + ' ' + type.toLowerCase() + ' ' + status;
+
+      const typeMatch = (activeFilter === 'All' || type === activeFilter);
+      const searchMatch = (!query || text.indexOf(query) !== -1);
+
+      if (typeMatch && searchMatch) {
+        row.classList.remove('hidden-row');
+        visible++;
+      } else {
+        row.classList.add('hidden-row');
+      }
+    });
+
+    document.getElementById('visible-count').textContent = visible;
+  }
+
+  // --- Row click highlighting ---
+  let selectedId = null;
+
+  tbody.addEventListener('click', function(e) {
+    // If clicking a connection link, scroll to that row
+    const connLink = e.target.closest('.conn-link');
+    if (connLink) {
+      e.preventDefault();
+      const targetId = connLink.getAttribute('data-target');
+      highlightRow(targetId);
+      const targetRow = document.getElementById(targetId);
+      if (targetRow) {
+        targetRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+      return;
+    }
+
+    // Otherwise highlight clicked row and its connections
+    const row = e.target.closest('tr.onto-row');
+    if (!row) return;
+    const rowId = row.getAttribute('data-id');
+
+    if (selectedId === rowId) {
+      clearHighlights();
+      selectedId = null;
+      return;
+    }
+
+    highlightRow(rowId);
+  });
+
+  function highlightRow(nodeId) {
+    clearHighlights();
+    selectedId = nodeId;
+
+    const row = document.getElementById(nodeId);
+    if (row) row.classList.add('highlighted');
+
+    const connected = CONN_MAP[nodeId] || [];
+    connected.forEach(function(cid) {
+      const cRow = document.getElementById(cid);
+      if (cRow) cRow.classList.add('connected-highlight');
+    });
+  }
+
+  function clearHighlights() {
+    tbody.querySelectorAll('tr').forEach(function(row) {
+      row.classList.remove('highlighted', 'connected-highlight');
+    });
+  }
+})();
+</script>
+
+</body>
+</html>

--- a/notes/analysis/2026-03-31-ontology-viz-comparison.md
+++ b/notes/analysis/2026-03-31-ontology-viz-comparison.md
@@ -1,0 +1,87 @@
+# Ontology Visualization Tool Comparison — 2026-03-31
+
+## Tools Tested
+
+### 1. pyvis (Python + D3.js) — SELECTED as primary
+- **Install:** `pip install pyvis` (requires networkx, jinja2)
+- **How it works:** Python script reads ontology data, builds network graph, outputs standalone HTML
+- **Test result:** Successfully generated interactive graph with 19 nodes, 22 edges
+- **Output:** `catalog/exports/viz/ontology-graph.html` (12KB self-contained)
+- **Features:**
+  - Conditional formatting (color by type, size by importance, shape by category)
+  - Interactive (drag, zoom, hover for metadata)
+  - Self-contained HTML (works offline, can be hosted on GitHub Pages)
+  - Legend support (custom HTML overlay)
+  - Physics simulation (force-directed, Barnes-Hut)
+  - No server required
+  - No saved views (requires regeneration with different filters)
+  - Requires Python script to generate (not one-click)
+- **Verdict:** Best balance of features, flexibility, and simplicity. Can be automated via a skill.
+
+### 2. OntoSpy (Python CLI) — BROKEN
+- **Install:** `pip install ontospy`
+- **Test result:** FAILS on Python 3.12 — `SafeConfigParser` removed in 3.12
+- **Error:** `ImportError: cannot import name 'SafeConfigParser' from 'configparser'`
+- **Verdict:** Dead on current Python. Not usable.
+
+### 3. WebVOWL (hosted web)
+- **URL:** https://service.tib.eu/webvowl/
+- **How it works:** Upload OWL/TTL file, get VOWL visualization
+- **Test result:** Page loads, accepts file upload via drag-and-drop
+- **Features:**
+  - No install required
+  - Standard VOWL notation (well-known in semantic web community)
+  - Export to TTL
+  - Requires OWL2VOWL conversion (our TTL may need preprocessing)
+  - External dependency (hosted service may go down)
+  - No conditional formatting beyond VOWL defaults
+  - No automation possible (manual upload each time)
+- **Verdict:** Good for one-off schema visualization. Not suitable for daily use with instance data.
+
+### 4. isSemantic RDF Visualizer (web)
+- **URL:** https://issemantic.net/rdf-visualizer
+- **Test:** Not tested (paste-based, no automation)
+- **Verdict:** Too manual for regular use. Good for quick ad-hoc checks.
+
+### 5. VisGraph3 (web)
+- **URL:** https://visgraph3.github.io/
+- **Test:** Not tested
+- **Verdict:** Similar to isSemantic — browser-based, manual paste.
+
+### 6. OWLGrEd Online (web)
+- **URL:** https://owlgred.lumii.lv/online_visualization
+- **Test:** Not tested
+- **Verdict:** More of an ontology editor than visualizer. Overkill for our needs.
+
+### 7. open-ontologies MCP
+- **Test:** Checked all 43 tools — no visualization output (SVG/HTML/image)
+- **onto_stats:** Returns counts only
+- **onto_query:** Returns JSON/table data that can be fed to pyvis
+- **Verdict:** Not a visualizer, but good data source for pyvis script
+
+### 8. draw.io (fallback)
+- **How:** SPARQL query -> build Mermaid/XML -> mcp__drawio__open_drawio_xml -> save .drawio
+- **Pros:** Already integrated, editable diagrams, version-controlled
+- **Cons:** Manual layout, doesn't auto-update from ontology, not interactive
+- **Verdict:** Good for presentation-quality static diagrams. Not for exploration.
+
+## Decision
+
+| Context | Tool | Format |
+|---------|------|--------|
+| **Local exploration** | pyvis (Python script) | Interactive HTML |
+| **Web/git sharing** | pyvis output (static HTML) | Host on GitHub Pages or commit HTML |
+| **Presentation export** | draw.io (via diagram-refresh skill) | .drawio -> PNG/SVG |
+| **Schema visualization** | WebVOWL (one-off) | Upload to hosted service |
+
+### Implementation Plan
+1. Create `scripts/viz-ontology.py` — reads graph TTL, generates pyvis HTML to `catalog/exports/viz/`
+2. Add to diagram-refresh skill as an optional step
+3. For web sharing: the HTML file is self-contained, can be served from anywhere
+
+## What pyvis gives us that others don't
+- **Conditional formatting:** nodes colored by type, sized by importance — built into the script
+- **Attribute display:** hover shows metadata (type, label, URI)
+- **Automation:** Python script can be run from CLI or via skill
+- **Self-contained output:** single HTML file, no server needed
+- **Customizable:** change colors, physics, layout by editing the script

--- a/notes/decisions.md
+++ b/notes/decisions.md
@@ -35,3 +35,12 @@
 - No automated Google Drive → local export → RAG ingest flow yet
 - This is the #1 blocker for daily operations
 - Needs: sync-library skill implementation
+
+## 2026-03-31 — Ontology visualization
+
+- Primary tool: pyvis (Python) → standalone interactive HTML
+- OntoSpy broken on Python 3.12
+- WebVOWL for one-off schema views
+- draw.io for presentation-quality static diagrams
+- Pyvis script at scripts/viz-ontology.py (to be created)
+- Output to catalog/exports/viz/ontology-graph.html

--- a/scripts/viz-ontology-table.py
+++ b/scripts/viz-ontology-table.py
@@ -1,0 +1,620 @@
+#!/usr/bin/env python3
+"""Generate table view of ontology entities.
+
+Usage:
+    python3 scripts/viz-ontology-table.py [output_path]
+
+Default output: catalog/exports/viz/ontology-table.html
+
+No external dependencies — uses only Python standard library.
+"""
+
+import sys
+import os
+import json
+
+OUTPUT = sys.argv[1] if len(sys.argv) > 1 else "catalog/exports/viz/ontology-table.html"
+
+# Color map by entity type (same as graph script)
+TYPE_COLORS = {
+    "Document": "#4A90D9",
+    "Topic": "#F5A623",
+    "Lecture": "#7ED321",
+    "SlideDeck": "#9B59B6",
+    "Diagram": "#1ABC9C",
+    "Requirement": "#E74C3C",
+    "Task": "#95A5A6",
+    "Section": "#F39C12",
+}
+
+STATUS_COLORS = {
+    "active": "#27ae60",
+    "archived": "#95a5a6",
+    "draft": "#f1c40f",
+}
+
+REPO_BASE = "https://github.com/tellina-study/AI-usage-lessons/blob/main/"
+
+# Node data (same as graph script)
+NODES = [
+    {"id": "doc_v2", "label": "AI в разных индустриях (V2)", "type": "Document", "status": "active",
+     "url": "https://docs.google.com/document/d/1k0ASel9hqLeBhtaDjS8k83Kpf640WFe8lln_MaV-OFY/edit",
+     "local_path": "catalog/exports/docs/ai-v-raznyh-industriyah.md",
+     "updated_at": "2026-03-06", "owner": "kzlevko@gmail.com"},
+    {"id": "doc_v1", "label": "AI в цикле создания ПО (V1)", "type": "Document", "status": "archived",
+     "url": "https://docs.google.com/document/d/1UliavdtqqZAyHu-JYDOGPFCbJZ44Enhju5TwmqV99Xg/edit",
+     "local_path": "catalog/exports/docs/ai-v-tsikle-sozdaniya-po.md",
+     "updated_at": "2026-02-23", "owner": "kzlevko@gmail.com"},
+    {"id": "doc_rpd_old", "label": "РПД (original)", "type": "Document", "status": "archived",
+     "url": "https://docs.google.com/document/d/18AFEqywR2utCu6a99zPuNa0MrIKYGmFd5ZWqKbu-6YE/edit",
+     "local_path": "catalog/exports/docs/prog-otraslevoe-primenenie-AI.md",
+     "updated_at": "2026-03-30", "owner": "kzlevko@gmail.com"},
+    {"id": "doc_rpd_new", "label": "РПД (updated)", "type": "Document", "status": "active",
+     "url": "https://docs.google.com/document/d/1zgAWfdyWlJBFMElmtKpmjgxySUCRccF9lNT-tj7J4fU/edit",
+     "local_path": "catalog/exports/docs/prog-otraslevoe-updated-formal.md",
+     "updated_at": "2026-03-31", "owner": "kzlevko@gmail.com"},
+    {"id": "doc_fos", "label": "ФОС", "type": "Document", "status": "active",
+     "url": "https://docs.google.com/document/d/1adJu0mKKIRgNHKRVNwVSdTI6sVdSykay/edit",
+     "local_path": "catalog/exports/docs/fos_otraslevoe_primenenie_AI.docx",
+     "updated_at": "2026-03-30", "owner": "kzlevko@gmail.com"},
+    {"id": "t_sw", "label": "AI в ПО", "type": "Topic"},
+    {"id": "t_fin", "label": "AI в финансах", "type": "Topic"},
+    {"id": "t_med", "label": "AI в медицине", "type": "Topic"},
+    {"id": "t_mfg", "label": "AI в производстве", "type": "Topic"},
+    {"id": "t_gov", "label": "AI в госуправлении", "type": "Topic"},
+    {"id": "t_cre", "label": "AI в креативе", "type": "Topic"},
+    {"id": "t_eth", "label": "Этика AI", "type": "Topic"},
+    {"id": "t_prm", "label": "Промптинг", "type": "Topic"},
+    {"id": "t_rec", "label": "Рек. системы", "type": "Topic"},
+    {"id": "t_exp", "label": "Эксп. системы", "type": "Topic"},
+    {"id": "lec_1", "label": "Лекция 1: Введение", "type": "Lecture", "status": "draft",
+     "url": "https://docs.google.com/document/d/1TsPeWdhgje3pj4yXMQrA9MDFb-hD9Ljed4hao7n-Ft8/edit",
+     "updated_at": "2026-03-31"},
+    {"id": "deck_1", "label": "Слайды Л1", "type": "SlideDeck", "status": "draft",
+     "url": "https://docs.google.com/presentation/d/1BviVqnn7vtHGg09h22UzfUTyQswTHfvSXqol_JaRTyM/edit",
+     "updated_at": "2026-03-31"},
+    {"id": "deck_old", "label": "ИИ и мир (old)", "type": "SlideDeck", "status": "archived",
+     "local_path": "catalog/exports/slides/ii-i-mir.pptx"},
+    {"id": "diag_roadmap", "label": "Семестровый план", "type": "Diagram", "status": "active",
+     "local_path": "diagrams/lecture-flows/semester-roadmap.drawio",
+     "git_url": "https://github.com/tellina-study/AI-usage-lessons/blob/main/diagrams/lecture-flows/semester-roadmap.drawio"},
+]
+
+# Edge data (same as graph script)
+EDGES = [
+    {"source": "doc_v2", "target": "doc_v1", "relation": "supersedes"},
+    {"source": "doc_rpd_new", "target": "doc_rpd_old", "relation": "supersedes"},
+    {"source": "doc_v2", "target": "doc_rpd_new", "relation": "depends_on"},
+    {"source": "doc_fos", "target": "doc_rpd_old", "relation": "depends_on"},
+    {"source": "doc_fos", "target": "doc_rpd_old", "relation": "cites"},
+    {"source": "deck_1", "target": "lec_1", "relation": "depends_on"},
+    {"source": "diag_roadmap", "target": "doc_v2", "relation": "illustrates"},
+    {"source": "doc_v2", "target": "t_sw", "relation": "belongs_to_topic"},
+    {"source": "doc_v2", "target": "t_fin", "relation": "belongs_to_topic"},
+    {"source": "doc_v2", "target": "t_med", "relation": "belongs_to_topic"},
+    {"source": "doc_v2", "target": "t_mfg", "relation": "belongs_to_topic"},
+    {"source": "doc_v2", "target": "t_gov", "relation": "belongs_to_topic"},
+    {"source": "doc_v2", "target": "t_cre", "relation": "belongs_to_topic"},
+    {"source": "doc_v2", "target": "t_eth", "relation": "belongs_to_topic"},
+    {"source": "doc_v2", "target": "t_prm", "relation": "belongs_to_topic"},
+    {"source": "doc_rpd_old", "target": "t_rec", "relation": "belongs_to_topic"},
+    {"source": "doc_rpd_old", "target": "t_exp", "relation": "belongs_to_topic"},
+    {"source": "doc_fos", "target": "t_rec", "relation": "belongs_to_topic"},
+    {"source": "doc_fos", "target": "t_exp", "relation": "belongs_to_topic"},
+    {"source": "lec_1", "target": "t_sw", "relation": "covers"},
+    {"source": "lec_1", "target": "t_eth", "relation": "covers"},
+    {"source": "lec_1", "target": "t_prm", "relation": "covers"},
+]
+
+
+def build_node_lookup():
+    """Build a dict from node id to node data."""
+    return {n["id"]: n for n in NODES}
+
+
+def get_connections(node_id, lookup):
+    """Get all connections for a node as a list of (direction, relation, target_id, target_label)."""
+    connections = []
+    for e in EDGES:
+        if e["source"] == node_id:
+            target = lookup.get(e["target"], {})
+            connections.append(("out", e["relation"], e["target"], target.get("label", e["target"])))
+        if e["target"] == node_id:
+            source = lookup.get(e["source"], {})
+            connections.append(("in", e["relation"], e["source"], source.get("label", e["source"])))
+    return connections
+
+
+def esc(text):
+    """Escape HTML entities."""
+    return (text
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace('"', "&quot;")
+            .replace("'", "&#39;"))
+
+
+def build_links_html(node):
+    """Build the Links cell content."""
+    parts = []
+    if node.get("url"):
+        parts.append(f'<a href="{esc(node["url"])}" target="_blank" class="link-badge link-drive">Drive</a>')
+    if node.get("git_url"):
+        parts.append(f'<a href="{esc(node["git_url"])}" target="_blank" class="link-badge link-github">GitHub</a>')
+    elif node.get("local_path"):
+        gh_url = REPO_BASE + node["local_path"]
+        parts.append(f'<a href="{esc(gh_url)}" target="_blank" class="link-badge link-github">GitHub</a>')
+    return " ".join(parts) if parts else '<span class="no-links">--</span>'
+
+
+def build_connections_html(node_id, lookup):
+    """Build the Connected Objects cell content."""
+    conns = get_connections(node_id, lookup)
+    if not conns:
+        return '<span class="no-links">--</span>'
+    parts = []
+    for direction, relation, target_id, target_label in conns:
+        arrow = "&rarr;" if direction == "out" else "&larr;"
+        parts.append(
+            f'<span class="conn-item">'
+            f'{arrow} <b>{esc(relation)}</b>: '
+            f'<a href="#{esc(target_id)}" class="conn-link" data-target="{esc(target_id)}">'
+            f'{esc(target_label)}</a>'
+            f'</span>'
+        )
+    return "<br>".join(parts)
+
+
+def generate_table_rows(lookup):
+    """Generate HTML table rows for all nodes."""
+    rows = []
+    for node in NODES:
+        nid = node["id"]
+        ntype = node.get("type", "")
+        color = TYPE_COLORS.get(ntype, "#ccc")
+        status = node.get("status", "")
+        status_color = STATUS_COLORS.get(status, "#ccc")
+
+        row = (
+            f'<tr id="{esc(nid)}" class="onto-row" '
+            f'data-type="{esc(ntype)}" '
+            f'data-name="{esc(node["label"])}" '
+            f'data-status="{esc(status)}" '
+            f'data-id="{esc(nid)}">'
+            f'<td><span class="type-badge" style="background:{color}">{esc(ntype)}</span></td>'
+            f'<td class="name-cell">{esc(node["label"])}</td>'
+            f'<td>'
+            + (f'<span class="status-badge" style="background:{status_color}">{esc(status)}</span>'
+               if status else '<span class="no-links">--</span>')
+            + f'</td>'
+            f'<td>{build_links_html(node)}</td>'
+            f'<td class="conn-cell">{build_connections_html(nid, lookup)}</td>'
+            f'</tr>'
+        )
+        rows.append(row)
+    return "\n".join(rows)
+
+
+def get_unique_types():
+    """Get sorted unique types from NODES."""
+    types = sorted(set(n["type"] for n in NODES))
+    return types
+
+
+def generate_filter_buttons(types):
+    """Generate type filter buttons HTML."""
+    buttons = ['<button class="filter-btn active" data-filter="All">All</button>']
+    for t in types:
+        color = TYPE_COLORS.get(t, "#ccc")
+        buttons.append(
+            f'<button class="filter-btn" data-filter="{esc(t)}" '
+            f'style="--btn-color:{color}">{esc(t)}</button>'
+        )
+    return "\n".join(buttons)
+
+
+def generate_html():
+    lookup = build_node_lookup()
+    types = get_unique_types()
+
+    # Build connection map for JS (node_id -> list of connected node_ids)
+    conn_map = {}
+    for node in NODES:
+        nid = node["id"]
+        connected = set()
+        for e in EDGES:
+            if e["source"] == nid:
+                connected.add(e["target"])
+            if e["target"] == nid:
+                connected.add(e["source"])
+        conn_map[nid] = list(connected)
+
+    conn_map_json = json.dumps(conn_map, ensure_ascii=False)
+
+    html = f"""<!DOCTYPE html>
+<html lang="ru">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Ontology Table</title>
+<style>
+* {{ margin: 0; padding: 0; box-sizing: border-box; }}
+body {{
+  font-family: 'Segoe UI', system-ui, -apple-system, sans-serif;
+  background: #f5f6fa;
+  color: #333;
+  padding: 20px;
+  min-height: 100vh;
+}}
+h1 {{
+  font-size: 22px;
+  margin-bottom: 16px;
+  color: #2c3e50;
+}}
+.toolbar {{
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 12px;
+}}
+.filter-btn {{
+  padding: 5px 14px;
+  border: 2px solid #ddd;
+  border-radius: 20px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  color: #555;
+  transition: all 0.15s;
+}}
+.filter-btn:hover {{
+  border-color: #aaa;
+  background: #f0f0f0;
+}}
+.filter-btn.active {{
+  border-color: var(--btn-color, #4A90D9);
+  background: var(--btn-color, #4A90D9);
+  color: #fff;
+}}
+.search-box {{
+  margin-bottom: 12px;
+}}
+.search-box input {{
+  width: 100%;
+  max-width: 400px;
+  padding: 8px 14px;
+  border: 1px solid #ddd;
+  border-radius: 6px;
+  font-size: 14px;
+  outline: none;
+  transition: border-color 0.15s;
+}}
+.search-box input:focus {{
+  border-color: #4A90D9;
+  box-shadow: 0 0 0 2px rgba(74,144,217,0.15);
+}}
+.table-wrap {{
+  overflow-x: auto;
+  border-radius: 8px;
+  box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+}}
+table {{
+  width: 100%;
+  border-collapse: collapse;
+  background: #fff;
+  font-size: 14px;
+}}
+thead th {{
+  background: #2c3e50;
+  color: #fff;
+  padding: 10px 14px;
+  text-align: left;
+  font-weight: 600;
+  font-size: 13px;
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+  position: sticky;
+  top: 0;
+  z-index: 2;
+}}
+thead th:hover {{
+  background: #34495e;
+}}
+thead th .sort-arrow {{
+  margin-left: 4px;
+  font-size: 10px;
+  opacity: 0.5;
+}}
+thead th.sorted .sort-arrow {{
+  opacity: 1;
+}}
+tbody tr {{
+  transition: background 0.1s;
+}}
+tbody tr:nth-child(even) {{
+  background: #fafbfc;
+}}
+tbody tr:hover {{
+  background: #eef3f9;
+}}
+tbody tr.highlighted {{
+  background: #fff9e6 !important;
+}}
+tbody tr.connected-highlight {{
+  background: #f0f7ff !important;
+}}
+tbody tr.hidden-row {{
+  display: none;
+}}
+td {{
+  padding: 8px 14px;
+  border-bottom: 1px solid #eee;
+  vertical-align: top;
+}}
+.type-badge {{
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 12px;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}}
+.status-badge {{
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 12px;
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}}
+.name-cell {{
+  font-weight: 500;
+  min-width: 180px;
+}}
+.link-badge {{
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 500;
+  text-decoration: none;
+  margin-right: 4px;
+}}
+.link-drive {{
+  background: #e8f0fe;
+  color: #1a73e8;
+}}
+.link-drive:hover {{
+  background: #d2e3fc;
+}}
+.link-github {{
+  background: #f0f0f0;
+  color: #333;
+}}
+.link-github:hover {{
+  background: #e0e0e0;
+}}
+.no-links {{
+  color: #ccc;
+  font-size: 13px;
+}}
+.conn-cell {{
+  font-size: 13px;
+  line-height: 1.6;
+  min-width: 250px;
+}}
+.conn-item b {{
+  color: #666;
+  font-weight: 500;
+}}
+.conn-link {{
+  color: #4A90D9;
+  text-decoration: none;
+  cursor: pointer;
+}}
+.conn-link:hover {{
+  text-decoration: underline;
+}}
+.count-info {{
+  margin-bottom: 8px;
+  font-size: 13px;
+  color: #888;
+}}
+@media (max-width: 768px) {{
+  body {{ padding: 10px; }}
+  td, thead th {{ padding: 6px 8px; font-size: 13px; }}
+  .name-cell {{ min-width: 120px; }}
+  .conn-cell {{ min-width: 180px; }}
+}}
+</style>
+</head>
+<body>
+
+<h1>Ontology Table</h1>
+
+<div class="toolbar">
+{generate_filter_buttons(types)}
+</div>
+
+<div class="search-box">
+  <input type="text" id="search-input" placeholder="Search by name, type, status...">
+</div>
+
+<div class="count-info">Showing <span id="visible-count">{len(NODES)}</span> of {len(NODES)} entities</div>
+
+<div class="table-wrap">
+<table id="onto-table">
+<thead>
+<tr>
+  <th data-col="type">Type <span class="sort-arrow">&#9650;&#9660;</span></th>
+  <th data-col="name">Name <span class="sort-arrow">&#9650;&#9660;</span></th>
+  <th data-col="status">Status <span class="sort-arrow">&#9650;&#9660;</span></th>
+  <th>Links</th>
+  <th>Connected Objects</th>
+</tr>
+</thead>
+<tbody>
+{generate_table_rows(lookup)}
+</tbody>
+</table>
+</div>
+
+<script>
+(function() {{
+  const CONN_MAP = {conn_map_json};
+
+  // --- Sorting ---
+  const table = document.getElementById('onto-table');
+  const thead = table.querySelector('thead');
+  const tbody = table.querySelector('tbody');
+  let sortCol = null;
+  let sortAsc = true;
+
+  thead.querySelectorAll('th[data-col]').forEach(function(th) {{
+    th.addEventListener('click', function() {{
+      const col = th.getAttribute('data-col');
+      if (sortCol === col) {{
+        sortAsc = !sortAsc;
+      }} else {{
+        sortCol = col;
+        sortAsc = true;
+      }}
+
+      // Update header styles
+      thead.querySelectorAll('th').forEach(function(h) {{ h.classList.remove('sorted'); }});
+      th.classList.add('sorted');
+
+      const rows = Array.from(tbody.querySelectorAll('tr.onto-row'));
+      rows.sort(function(a, b) {{
+        let va = a.getAttribute('data-' + col) || '';
+        let vb = b.getAttribute('data-' + col) || '';
+        va = va.toLowerCase();
+        vb = vb.toLowerCase();
+        if (va < vb) return sortAsc ? -1 : 1;
+        if (va > vb) return sortAsc ? 1 : -1;
+        return 0;
+      }});
+
+      rows.forEach(function(row) {{ tbody.appendChild(row); }});
+    }});
+  }});
+
+  // --- Filtering by type ---
+  let activeFilter = 'All';
+  const filterBtns = document.querySelectorAll('.filter-btn');
+
+  filterBtns.forEach(function(btn) {{
+    btn.addEventListener('click', function() {{
+      filterBtns.forEach(function(b) {{ b.classList.remove('active'); }});
+      btn.classList.add('active');
+      activeFilter = btn.getAttribute('data-filter');
+      applyFilters();
+    }});
+  }});
+
+  // --- Search ---
+  const searchInput = document.getElementById('search-input');
+  searchInput.addEventListener('input', function() {{
+    applyFilters();
+  }});
+
+  function applyFilters() {{
+    const query = searchInput.value.toLowerCase().trim();
+    const rows = tbody.querySelectorAll('tr.onto-row');
+    let visible = 0;
+
+    rows.forEach(function(row) {{
+      const type = row.getAttribute('data-type');
+      const name = row.getAttribute('data-name').toLowerCase();
+      const status = row.getAttribute('data-status').toLowerCase();
+      const text = name + ' ' + type.toLowerCase() + ' ' + status;
+
+      const typeMatch = (activeFilter === 'All' || type === activeFilter);
+      const searchMatch = (!query || text.indexOf(query) !== -1);
+
+      if (typeMatch && searchMatch) {{
+        row.classList.remove('hidden-row');
+        visible++;
+      }} else {{
+        row.classList.add('hidden-row');
+      }}
+    }});
+
+    document.getElementById('visible-count').textContent = visible;
+  }}
+
+  // --- Row click highlighting ---
+  let selectedId = null;
+
+  tbody.addEventListener('click', function(e) {{
+    // If clicking a connection link, scroll to that row
+    const connLink = e.target.closest('.conn-link');
+    if (connLink) {{
+      e.preventDefault();
+      const targetId = connLink.getAttribute('data-target');
+      highlightRow(targetId);
+      const targetRow = document.getElementById(targetId);
+      if (targetRow) {{
+        targetRow.scrollIntoView({{ behavior: 'smooth', block: 'center' }});
+      }}
+      return;
+    }}
+
+    // Otherwise highlight clicked row and its connections
+    const row = e.target.closest('tr.onto-row');
+    if (!row) return;
+    const rowId = row.getAttribute('data-id');
+
+    if (selectedId === rowId) {{
+      clearHighlights();
+      selectedId = null;
+      return;
+    }}
+
+    highlightRow(rowId);
+  }});
+
+  function highlightRow(nodeId) {{
+    clearHighlights();
+    selectedId = nodeId;
+
+    const row = document.getElementById(nodeId);
+    if (row) row.classList.add('highlighted');
+
+    const connected = CONN_MAP[nodeId] || [];
+    connected.forEach(function(cid) {{
+      const cRow = document.getElementById(cid);
+      if (cRow) cRow.classList.add('connected-highlight');
+    }});
+  }}
+
+  function clearHighlights() {{
+    tbody.querySelectorAll('tr').forEach(function(row) {{
+      row.classList.remove('highlighted', 'connected-highlight');
+    }});
+  }}
+}})();
+</script>
+
+</body>
+</html>"""
+
+    return html
+
+
+if __name__ == "__main__":
+    os.makedirs(os.path.dirname(OUTPUT) or ".", exist_ok=True)
+    html = generate_html()
+
+    with open(OUTPUT, "w") as f:
+        f.write(html)
+
+    print(f"Ontology table saved to: {OUTPUT}")
+    print(f"Nodes: {len(NODES)}, Edges: {len(EDGES)}")
+    print(f"Open in browser: file://{os.path.abspath(OUTPUT)}")

--- a/scripts/viz-ontology.py
+++ b/scripts/viz-ontology.py
@@ -1,0 +1,452 @@
+#!/usr/bin/env python3
+"""Generate interactive ontology visualization with attribute panel and neighbor highlighting.
+
+Usage:
+    python3 scripts/viz-ontology.py [output_path]
+
+Default output: catalog/exports/viz/ontology-graph.html
+
+Requires: pip install pyvis
+"""
+
+import sys
+import os
+import json
+from pyvis.network import Network
+
+OUTPUT = sys.argv[1] if len(sys.argv) > 1 else "catalog/exports/viz/ontology-graph.html"
+
+# Color map by entity type
+TYPE_COLORS = {
+    "Document": "#4A90D9",
+    "Topic": "#F5A623",
+    "Lecture": "#7ED321",
+    "SlideDeck": "#9B59B6",
+    "Diagram": "#1ABC9C",
+    "Requirement": "#E74C3C",
+    "Task": "#95A5A6",
+    "Section": "#F39C12",
+}
+
+TYPE_SHAPES = {
+    "Document": "dot",
+    "Topic": "diamond",
+    "Lecture": "box",
+    "SlideDeck": "triangle",
+    "Diagram": "star",
+    "Requirement": "square",
+    "Task": "triangleDown",
+}
+
+RELATION_COLORS = {
+    "supersedes": "#E74C3C",
+    "depends_on": "#3498DB",
+    "cites": "#2ECC71",
+    "covers": "#F39C12",
+    "belongs_to_topic": "#9B59B6",
+    "illustrates": "#1ABC9C",
+    "tracked_by": "#95A5A6",
+}
+
+# Node data with links and attributes
+NODES = [
+    {"id": "doc_v2", "label": "AI в разных индустриях (V2)", "type": "Document", "status": "active",
+     "url": "https://docs.google.com/document/d/1k0ASel9hqLeBhtaDjS8k83Kpf640WFe8lln_MaV-OFY/edit",
+     "local_path": "catalog/exports/docs/ai-v-raznyh-industriyah.md",
+     "updated_at": "2026-03-06", "owner": "kzlevko@gmail.com"},
+    {"id": "doc_v1", "label": "AI в цикле создания ПО (V1)", "type": "Document", "status": "archived",
+     "url": "https://docs.google.com/document/d/1UliavdtqqZAyHu-JYDOGPFCbJZ44Enhju5TwmqV99Xg/edit",
+     "local_path": "catalog/exports/docs/ai-v-tsikle-sozdaniya-po.md",
+     "updated_at": "2026-02-23", "owner": "kzlevko@gmail.com"},
+    {"id": "doc_rpd_old", "label": "РПД (original)", "type": "Document", "status": "archived",
+     "url": "https://docs.google.com/document/d/18AFEqywR2utCu6a99zPuNa0MrIKYGmFd5ZWqKbu-6YE/edit",
+     "local_path": "catalog/exports/docs/prog-otraslevoe-primenenie-AI.md",
+     "updated_at": "2026-03-30", "owner": "kzlevko@gmail.com"},
+    {"id": "doc_rpd_new", "label": "РПД (updated)", "type": "Document", "status": "active",
+     "url": "https://docs.google.com/document/d/1zgAWfdyWlJBFMElmtKpmjgxySUCRccF9lNT-tj7J4fU/edit",
+     "local_path": "catalog/exports/docs/prog-otraslevoe-updated-formal.md",
+     "updated_at": "2026-03-31", "owner": "kzlevko@gmail.com"},
+    {"id": "doc_fos", "label": "ФОС", "type": "Document", "status": "active",
+     "url": "https://docs.google.com/document/d/1adJu0mKKIRgNHKRVNwVSdTI6sVdSykay/edit",
+     "local_path": "catalog/exports/docs/fos_otraslevoe_primenenie_AI.docx",
+     "updated_at": "2026-03-30", "owner": "kzlevko@gmail.com"},
+    {"id": "t_sw", "label": "AI в ПО", "type": "Topic"},
+    {"id": "t_fin", "label": "AI в финансах", "type": "Topic"},
+    {"id": "t_med", "label": "AI в медицине", "type": "Topic"},
+    {"id": "t_mfg", "label": "AI в производстве", "type": "Topic"},
+    {"id": "t_gov", "label": "AI в госуправлении", "type": "Topic"},
+    {"id": "t_cre", "label": "AI в креативе", "type": "Topic"},
+    {"id": "t_eth", "label": "Этика AI", "type": "Topic"},
+    {"id": "t_prm", "label": "Промптинг", "type": "Topic"},
+    {"id": "t_rec", "label": "Рек. системы", "type": "Topic"},
+    {"id": "t_exp", "label": "Эксп. системы", "type": "Topic"},
+    {"id": "lec_1", "label": "Лекция 1: Введение", "type": "Lecture", "status": "draft",
+     "url": "https://docs.google.com/document/d/1TsPeWdhgje3pj4yXMQrA9MDFb-hD9Ljed4hao7n-Ft8/edit",
+     "updated_at": "2026-03-31"},
+    {"id": "deck_1", "label": "Слайды Л1", "type": "SlideDeck", "status": "draft",
+     "url": "https://docs.google.com/presentation/d/1BviVqnn7vtHGg09h22UzfUTyQswTHfvSXqol_JaRTyM/edit",
+     "updated_at": "2026-03-31"},
+    {"id": "deck_old", "label": "ИИ и мир (old)", "type": "SlideDeck", "status": "archived",
+     "local_path": "catalog/exports/slides/ii-i-mir.pptx"},
+    {"id": "diag_roadmap", "label": "Семестровый план", "type": "Diagram", "status": "active",
+     "local_path": "diagrams/lecture-flows/semester-roadmap.drawio",
+     "git_url": "https://github.com/tellina-study/AI-usage-lessons/blob/main/diagrams/lecture-flows/semester-roadmap.drawio"},
+]
+
+EDGES = [
+    {"source": "doc_v2", "target": "doc_v1", "relation": "supersedes"},
+    {"source": "doc_rpd_new", "target": "doc_rpd_old", "relation": "supersedes"},
+    {"source": "doc_v2", "target": "doc_rpd_new", "relation": "depends_on"},
+    {"source": "doc_fos", "target": "doc_rpd_old", "relation": "depends_on"},
+    {"source": "doc_fos", "target": "doc_rpd_old", "relation": "cites"},
+    {"source": "deck_1", "target": "lec_1", "relation": "depends_on"},
+    {"source": "diag_roadmap", "target": "doc_v2", "relation": "illustrates"},
+    {"source": "doc_v2", "target": "t_sw", "relation": "belongs_to_topic"},
+    {"source": "doc_v2", "target": "t_fin", "relation": "belongs_to_topic"},
+    {"source": "doc_v2", "target": "t_med", "relation": "belongs_to_topic"},
+    {"source": "doc_v2", "target": "t_mfg", "relation": "belongs_to_topic"},
+    {"source": "doc_v2", "target": "t_gov", "relation": "belongs_to_topic"},
+    {"source": "doc_v2", "target": "t_cre", "relation": "belongs_to_topic"},
+    {"source": "doc_v2", "target": "t_eth", "relation": "belongs_to_topic"},
+    {"source": "doc_v2", "target": "t_prm", "relation": "belongs_to_topic"},
+    {"source": "doc_rpd_old", "target": "t_rec", "relation": "belongs_to_topic"},
+    {"source": "doc_rpd_old", "target": "t_exp", "relation": "belongs_to_topic"},
+    {"source": "doc_fos", "target": "t_rec", "relation": "belongs_to_topic"},
+    {"source": "doc_fos", "target": "t_exp", "relation": "belongs_to_topic"},
+    {"source": "lec_1", "target": "t_sw", "relation": "covers"},
+    {"source": "lec_1", "target": "t_eth", "relation": "covers"},
+    {"source": "lec_1", "target": "t_prm", "relation": "covers"},
+]
+
+# Build node lookup for JS
+NODE_DATA = {}
+for n in NODES:
+    NODE_DATA[n["id"]] = {k: v for k, v in n.items() if k != "id"}
+
+
+def build_graph(nodes, edges):
+    net = Network(height="100vh", width="100%", directed=True, bgcolor="#fafafa", font_color="#333")
+    net.barnes_hut(gravity=-4000, spring_length=180, damping=0.5)
+
+    for node in nodes:
+        color = TYPE_COLORS.get(node["type"], "#cccccc")
+        shape = TYPE_SHAPES.get(node["type"], "dot")
+        size = 30 if node["type"] == "Document" else 25 if node["type"] == "Lecture" else 20
+        border_color = "#666" if node.get("status") == "archived" else color
+        net.add_node(
+            node["id"], label=node["label"], color={"background": color, "border": border_color,
+            "highlight": {"background": "#FFD700", "border": "#FF8C00"}},
+            shape=shape, size=size, borderWidth=2,
+            font={"size": 12, "color": "#333", "strokeWidth": 2, "strokeColor": "#fff"},
+        )
+
+    for edge in edges:
+        color = RELATION_COLORS.get(edge["relation"], "#999")
+        net.add_edge(
+            edge["source"], edge["target"],
+            label=edge["relation"], color={"color": color, "highlight": "#FF8C00", "opacity": 0.8},
+            arrows="to", width=2, font={"size": 9, "color": color, "strokeWidth": 0},
+            smooth={"type": "curvedCW", "roundness": 0.15},
+        )
+
+    return net
+
+
+def build_html(net):
+    """Generate the HTML with custom attribute panel and neighbor highlighting."""
+    net.set_options(json.dumps({
+        "physics": {
+            "barnesHut": {"gravitationalConstant": -4000, "springLength": 180, "damping": 0.5}
+        },
+        "interaction": {
+            "hover": True, "tooltipDelay": 100, "hideEdgesOnDrag": True,
+            "multiselect": True, "navigationButtons": True
+        },
+        "edges": {"smooth": {"type": "curvedCW", "roundness": 0.15}},
+    }))
+
+    net.save_graph(OUTPUT)
+
+    with open(OUTPUT, "r") as f:
+        html = f.read()
+
+    # Inject custom CSS + JS for attribute panel and neighbor highlighting
+    custom_css = """
+<style>
+  html, body { margin: 0; padding: 0; height: 100%; overflow: hidden; font-family: 'Segoe UI', sans-serif; }
+  #mynetwork { position: absolute; left: 0; top: 0; right: 300px; bottom: 0; min-height: 600px; border-right: 1px solid #ddd; }
+  #panel { position: absolute; right: 0; top: 0; width: 300px; bottom: 0; overflow-y: auto; background: #fff; padding: 16px; box-sizing: border-box; }
+  #panel h3 { margin: 0 0 8px 0; color: #333; font-size: 16px; }
+  #panel .type-badge { display: inline-block; padding: 2px 8px; border-radius: 4px; color: #fff; font-size: 11px; font-weight: bold; margin-bottom: 8px; }
+  #panel .attr { margin: 6px 0; font-size: 13px; }
+  #panel .attr-label { color: #888; font-size: 11px; text-transform: uppercase; letter-spacing: 0.5px; }
+  #panel .attr-value { color: #333; word-break: break-all; }
+  #panel a { color: #4A90D9; text-decoration: none; }
+  #panel a:hover { text-decoration: underline; }
+  #panel .relations { margin-top: 12px; border-top: 1px solid #eee; padding-top: 8px; }
+  #panel .rel { margin: 4px 0; font-size: 12px; }
+  #panel .rel-arrow { color: #999; }
+  #panel .empty { color: #999; font-style: italic; padding: 40px 0; text-align: center; }
+  #legend { padding: 12px 0; border-bottom: 1px solid #eee; margin-bottom: 12px; font-size: 12px; }
+  #legend b { font-size: 13px; }
+  .leg-item { margin: 2px 0; }
+  .leg-dot { display: inline-block; width: 10px; height: 10px; border-radius: 50%; margin-right: 4px; vertical-align: middle; }
+  .leg-line { display: inline-block; width: 20px; height: 2px; margin-right: 4px; vertical-align: middle; }
+  #type-toolbar { position: fixed; top: 0; left: 0; right: 300px; height: 40px; background: #fff; border-bottom: 1px solid #ddd; display: flex; align-items: center; gap: 8px; padding: 0 16px; z-index: 10; box-sizing: border-box; }
+  #mynetwork { top: 40px !important; }
+  .type-btn { border: none; padding: 5px 14px; border-radius: 20px; font-size: 12px; font-weight: 600; cursor: pointer; color: #fff; opacity: 0.7; transition: opacity 0.15s, box-shadow 0.15s; }
+  .type-btn:hover { opacity: 0.9; }
+  .type-btn.active { opacity: 1; box-shadow: 0 0 0 2px rgba(0,0,0,0.25); }
+</style>
+"""
+
+    filter_types = ["Document", "Topic", "Lecture", "SlideDeck", "Diagram"]
+    toolbar_buttons = '<button class="type-btn active" data-type="All" style="background:#666" onclick="filterByType(\'All\', this)">All</button>'
+    for t in filter_types:
+        c = TYPE_COLORS.get(t, "#999")
+        toolbar_buttons += f'<button class="type-btn" data-type="{t}" style="background:{c}" onclick="filterByType(\'{t}\', this)">{t}</button>'
+
+    custom_panel = """
+<div id="type-toolbar">""" + toolbar_buttons + """</div>
+<div id="panel">
+  <div id="legend">
+    <b>Ontology Graph</b><br>
+    <div style="margin-top:6px"><b>Entities</b></div>
+    <div class="leg-item"><span class="leg-dot" style="background:#4A90D9"></span>Document</div>
+    <div class="leg-item"><span class="leg-dot" style="background:#F5A623"></span>Topic</div>
+    <div class="leg-item"><span class="leg-dot" style="background:#7ED321"></span>Lecture</div>
+    <div class="leg-item"><span class="leg-dot" style="background:#9B59B6"></span>SlideDeck</div>
+    <div class="leg-item"><span class="leg-dot" style="background:#1ABC9C"></span>Diagram</div>
+    <div style="margin-top:6px"><b>Relations</b></div>
+    <div class="leg-item"><span class="leg-line" style="background:#E74C3C"></span>supersedes</div>
+    <div class="leg-item"><span class="leg-line" style="background:#3498DB"></span>depends_on</div>
+    <div class="leg-item"><span class="leg-line" style="background:#2ECC71"></span>cites</div>
+    <div class="leg-item"><span class="leg-line" style="background:#9B59B6"></span>belongs_to_topic</div>
+    <div class="leg-item"><span class="leg-line" style="background:#F39C12"></span>covers</div>
+    <div class="leg-item"><span class="leg-line" style="background:#1ABC9C"></span>illustrates</div>
+  </div>
+  <div id="details">
+    <div class="empty">Click a node to see details</div>
+  </div>
+</div>
+"""
+
+    node_data_json = json.dumps(NODE_DATA, ensure_ascii=False)
+    edges_json = json.dumps(EDGES, ensure_ascii=False)
+
+    custom_js = """
+<script>
+const NODE_DATA = """ + node_data_json + """;
+const EDGES = """ + edges_json + """;
+const TYPE_COLORS = """ + json.dumps(TYPE_COLORS) + """;
+
+const REPO = "https://github.com/tellina-study/AI-usage-lessons/blob/main/";
+
+// Wait for vis network to initialize
+setTimeout(function() {
+  var network = Object.values(document.getElementById('mynetwork'))[0]
+    || window.network;
+
+  // Try to find the network instance
+  var frames = document.querySelectorAll('iframe');
+  if (!network) {
+    // pyvis stores network on the window of the iframe or directly
+    network = window.network;
+  }
+
+  if (!network) return;
+
+  var allNodes = null;
+  var allEdges = null;
+
+  try {
+    allNodes = network.body.data.nodes;
+    allEdges = network.body.data.edges;
+  } catch(e) {}
+
+  // Click handler — show attributes panel
+  network.on("click", function(params) {
+    var panel = document.getElementById("details");
+    if (params.nodes.length === 0) {
+      panel.innerHTML = '<div class="empty">Click a node to see details</div>';
+      resetHighlight();
+      return;
+    }
+
+    var nodeId = params.nodes[0];
+    var data = NODE_DATA[nodeId];
+    if (!data) {
+      panel.innerHTML = '<div class="empty">No data for ' + nodeId + '</div>';
+      return;
+    }
+
+    var color = TYPE_COLORS[data.type] || "#ccc";
+    var html = '<h3>' + data.label + '</h3>';
+    html += '<span class="type-badge" style="background:' + color + '">' + data.type + '</span>';
+
+    // Attributes
+    if (data.status) html += '<div class="attr"><div class="attr-label">Status</div><div class="attr-value">' + data.status + '</div></div>';
+    if (data.updated_at) html += '<div class="attr"><div class="attr-label">Updated</div><div class="attr-value">' + data.updated_at + '</div></div>';
+    if (data.owner) html += '<div class="attr"><div class="attr-label">Owner</div><div class="attr-value">' + data.owner + '</div></div>';
+
+    // Links
+    html += '<div class="attr" style="margin-top:12px"><div class="attr-label">Links</div></div>';
+    if (data.url) html += '<div class="attr"><a href="' + data.url + '" target="_blank">📄 Open in Google Drive</a></div>';
+    if (data.local_path) html += '<div class="attr"><a href="' + REPO + data.local_path + '" target="_blank">📁 View in GitHub</a></div>';
+    if (data.git_url) html += '<div class="attr"><a href="' + data.git_url + '" target="_blank">📁 View in GitHub</a></div>';
+
+    // Relations
+    html += '<div class="relations"><div class="attr-label">Relations</div>';
+    var outgoing = EDGES.filter(e => e.source === nodeId);
+    var incoming = EDGES.filter(e => e.target === nodeId);
+
+    outgoing.forEach(function(e) {
+      var targetData = NODE_DATA[e.target] || {label: e.target};
+      html += '<div class="rel"><span class="rel-arrow">→</span> <b>' + e.relation + '</b> ' + targetData.label + '</div>';
+    });
+    incoming.forEach(function(e) {
+      var sourceData = NODE_DATA[e.source] || {label: e.source};
+      html += '<div class="rel"><span class="rel-arrow">←</span> <b>' + e.relation + '</b> ' + sourceData.label + '</div>';
+    });
+    if (outgoing.length === 0 && incoming.length === 0) html += '<div class="rel" style="color:#999">No relations</div>';
+    html += '</div>';
+
+    panel.innerHTML = html;
+
+    // Highlight connected nodes
+    highlightNeighbors(nodeId);
+  });
+
+  function highlightNeighbors(nodeId) {
+    if (!allNodes || !allEdges) return;
+
+    var connectedNodes = new Set([nodeId]);
+    var connectedEdges = new Set();
+
+    allEdges.forEach(function(edge) {
+      var edgeData = allEdges.get(edge.id);
+      if (edgeData.from === nodeId || edgeData.to === nodeId) {
+        connectedNodes.add(edgeData.from);
+        connectedNodes.add(edgeData.to);
+        connectedEdges.add(edge.id);
+      }
+    });
+
+    // Dim non-connected nodes
+    var updates = [];
+    allNodes.forEach(function(node) {
+      if (connectedNodes.has(node.id)) {
+        updates.push({id: node.id, opacity: 1.0, font: {color: "#333"}});
+      } else {
+        updates.push({id: node.id, opacity: 0.15, font: {color: "#ccc"}});
+      }
+    });
+    allNodes.update(updates);
+
+    // Dim non-connected edges
+    var edgeUpdates = [];
+    allEdges.forEach(function(edge) {
+      if (connectedEdges.has(edge.id)) {
+        edgeUpdates.push({id: edge.id, hidden: false, width: 3});
+      } else {
+        edgeUpdates.push({id: edge.id, hidden: true});
+      }
+    });
+    allEdges.update(edgeUpdates);
+  }
+
+  function resetHighlight() {
+    if (!allNodes || !allEdges) return;
+    var updates = [];
+    allNodes.forEach(function(node) {
+      updates.push({id: node.id, hidden: false, opacity: 1.0, font: {color: "#333"}});
+    });
+    allNodes.update(updates);
+
+    var edgeUpdates = [];
+    allEdges.forEach(function(edge) {
+      edgeUpdates.push({id: edge.id, hidden: false, width: 2});
+    });
+    allEdges.update(edgeUpdates);
+  }
+
+  // Type filter logic — exposed globally so onclick can call it
+  window.filterByType = function(type, btnEl) {
+    // Update active button
+    document.querySelectorAll('.type-btn').forEach(function(b) { b.classList.remove('active'); });
+    if (btnEl) btnEl.classList.add('active');
+
+    if (!allNodes || !allEdges) return;
+
+    if (type === 'All') {
+      resetHighlight();
+      return;
+    }
+
+    // Find nodes of selected type
+    var selectedIds = new Set();
+    allNodes.forEach(function(node) {
+      if (NODE_DATA[node.id] && NODE_DATA[node.id].type === type) {
+        selectedIds.add(node.id);
+      }
+    });
+
+    // Find directly connected nodes (one hop)
+    var visibleIds = new Set(selectedIds);
+    allEdges.forEach(function(edge) {
+      var edgeData = allEdges.get(edge.id);
+      if (selectedIds.has(edgeData.from)) visibleIds.add(edgeData.to);
+      if (selectedIds.has(edgeData.to)) visibleIds.add(edgeData.from);
+    });
+
+    // Show/hide nodes
+    var nodeUpdates = [];
+    allNodes.forEach(function(node) {
+      if (visibleIds.has(node.id)) {
+        nodeUpdates.push({id: node.id, hidden: false, opacity: 1.0, font: {color: "#333"}});
+      } else {
+        nodeUpdates.push({id: node.id, hidden: true});
+      }
+    });
+    allNodes.update(nodeUpdates);
+
+    // Show edges only between visible nodes
+    var edgeUpdates = [];
+    allEdges.forEach(function(edge) {
+      var edgeData = allEdges.get(edge.id);
+      if (visibleIds.has(edgeData.from) && visibleIds.has(edgeData.to)) {
+        edgeUpdates.push({id: edge.id, hidden: false, width: 2});
+      } else {
+        edgeUpdates.push({id: edge.id, hidden: true});
+      }
+    });
+    allEdges.update(edgeUpdates);
+  };
+
+}, 1000);
+</script>
+"""
+
+    # Inject into HTML
+    html = html.replace("<head>", "<head>" + custom_css)
+    html = html.replace("</body>", custom_panel + custom_js + "</body>")
+
+    # Fix pyvis container to fill the viewport properly
+    html = html.replace('style="width: 100%; height: 100vh;"', 'style="width: 100%; height: 100vh;"')
+    # Ensure the canvas div also fills height
+    html = html.replace('#mynetwork {', '#mynetwork { min-height: 600px; ')
+
+    return html
+
+
+if __name__ == "__main__":
+    os.makedirs(os.path.dirname(OUTPUT) or ".", exist_ok=True)
+    net = build_graph(NODES, EDGES)
+    html = build_html(net)
+
+    with open(OUTPUT, "w") as f:
+        f.write(html)
+
+    print(f"Ontology visualization saved to: {OUTPUT}")
+    print(f"Nodes: {len(NODES)}, Edges: {len(EDGES)}")
+    print(f"Open in browser: file://{os.path.abspath(OUTPUT)}")


### PR DESCRIPTION
## Summary
- Interactive graph view (pyvis) with type filter toolbar, attribute panel, Drive/GitHub links, neighbor highlighting
- Table view with sortable columns, search, connected objects, row highlighting
- Index page with tab switching between views
- Tool comparison: 8 tools evaluated, pyvis selected (OntoSpy broken on Py3.12)

## How to use
```bash
python3 scripts/viz-ontology.py        # generates graph HTML
python3 scripts/viz-ontology-table.py  # generates table HTML
# Open catalog/exports/viz/index.html in browser
```

## Test plan
- [x] Graph renders 19 nodes, 22 edges
- [x] Filter buttons show/hide by type
- [x] Click node → attribute panel with links
- [x] Neighbor highlighting on click
- [x] Table shows all entities with connected objects
- [x] Table search and sort work
- [x] Index page tabs switch between views

🤖 Generated with [Claude Code](https://claude.com/claude-code)