### PR TITLE
Research: 7 KM approaches + 4 retrieval strategies #18

### DIFF
--- a/notes/research/knowledge-architecture-comparison-part1.md
+++ b/notes/research/knowledge-architecture-comparison-part1.md
@@ -1,0 +1,214 @@
+---
+title: "Knowledge Architecture for LLM-Native Workflows: A Comparative Analysis"
+part: 1
+parts_total: 3
+description: "Part 1: Seven approaches to knowledge management — from Karpathy's LLM Wiki to Kubernetes docs-as-code, analyzed with raw source code from real implementations"
+issue: "#18"
+epic: "#17"
+date: 2026-04-07
+---
+
+# Knowledge Architecture for LLM-Native Workflows
+
+> Part 1 of 3: Seven Approaches Compared
+> See also: [Part 2 — Retrieval Strategies](knowledge-architecture-comparison-part2.md) | [Part 3 — Our Architecture](knowledge-architecture-comparison-part3.md)
+
+## Why Knowledge Architecture Matters Now
+
+LLMs have fundamentally changed the knowledge management game. For decades, the debate centered on "folders vs tags vs links" — a question about human navigation ergonomics. Now the question is different: how should I organize knowledge so an LLM can navigate it?
+
+This shift matters because LLMs are not just consumers of knowledge — they are maintainers. An LLM can read a thousand markdown files, build an index, detect gaps, and cross-reference concepts in ways no human would bother doing manually. The organizational structure you choose determines what the LLM can do with your knowledge.
+
+The key insight from surveying real implementations: at moderate scale (up to a few hundred sources), a well-structured markdown wiki with an LLM-maintained index can outperform RAG. The index is small enough to fit in context, the LLM knows exactly where everything lives, and retrieval is precise. But at thousands of sources, the index itself exceeds context limits, and you need a hybrid approach — hierarchical indexes, vector search, and graph traversal working together.
+
+This three-part series analyzes seven approaches to knowledge architecture, examines their retrieval strategies, and then describes how we combined elements of each into a working system for a university course with hundreds of source documents.
+
+## 1. Karpathy's LLM Wiki
+
+**Core idea:** Three-layer architecture (raw/wiki/schema). The LLM reads raw sources, compiles wiki pages, maintains an index. The index is the primary retrieval mechanism — no vector DB needed at personal scale.
+
+**Raw source analysis:** Karpathy's gist defines three operations: Ingest, Query, Lint. The key files are `index.md` (catalog of all wiki pages with one-line summaries) and `log.md` (append-only record of all operations performed). The LLM decides what wiki pages to create or update after ingesting a new source — it is both the writer and the librarian.
+
+The folder structure is intentionally minimal:
+
+```
+raw/           -- immutable source documents
+wiki/          -- LLM-generated markdown (summaries, entity pages, comparisons)
+CLAUDE.md      -- schema/conventions doc
+```
+
+The `raw/` directory is append-only: you never edit sources, only add new ones. The `wiki/` directory is entirely LLM-generated and LLM-maintained. `CLAUDE.md` defines the conventions the LLM follows when creating wiki pages — naming rules, required sections, cross-reference format.
+
+**Real implementations:**
+
+Three independent implementations of the LLM Wiki concept reveal what happens when the idea meets production:
+
+- **ussumant/llm-wiki-compiler:** A Claude Code plugin that adds coverage indicators (high/medium/low per section) to track how well wiki articles cover their source material. In one test run, 383 source files were compressed to 13 wiki articles — an 81x compression ratio. Concept articles are auto-discovered when a topic appears across 3+ sources. The coverage system ensures no source material is silently dropped.
+
+- **atomicmemory/llm-wiki-compiler:** A TypeScript + Anthropic API implementation that uses structured tool_use for concept extraction. The cross-reference resolver walks all wiki pages after each update to ensure bidirectional links are consistent. Includes orphan page detection — wiki pages that exist but are not referenced from the index or any other page.
+
+- **xoai/sage-wiki:** A Go production-grade implementation with a 5-pass pipeline: diff detection, summarization, concept extraction, article writing, and embedding generation. Combines hybrid BM25 + vector search for retrieval. Uses SQLite as the backend with checkpoint/resume support for interrupted ingestion runs.
+
+**Scale characteristics:** At approximately 100 sources, index-only retrieval works well. The entire `index.md` fits comfortably in context, and the LLM can find any page by scanning summaries. At approximately 500+ sources, every implementation adds something beyond the basic index: sage-wiki adds vector search, ussumant adds coverage indicators to prioritize retrieval, and atomicmemory adds dependency graphs to navigate related concepts. Karpathy himself notes that RAG becomes necessary "beyond a few hundred articles or millions of words."
+
+**Key code snippet** from atomicmemory's concept extraction:
+
+```typescript
+CONCEPT_EXTRACTION_TOOL = {
+  name: "extract_concepts",
+  input_schema: {
+    concepts: [{
+      concept: "string",
+      summary: "string",
+      is_new: "boolean"
+    }]
+  }
+}
+```
+
+The `is_new` flag is critical — it tells the system whether to create a new wiki page or update an existing one, preventing duplicate pages for the same concept under slightly different names.
+
+## 2. Zettelkasten (Dendron, Foam, note-link-janitor)
+
+**Core idea:** Atomic notes, bidirectional links, emergent structure from connections not categories. Each note captures one idea, links to related ideas, and the structure of knowledge emerges from the link graph rather than from a predetermined hierarchy.
+
+**Dendron's hierarchy model:** Dendron takes a unique approach — dot-separated filenames AS the hierarchy. The file `lang.python.data.string.md` represents the path `lang > python > data > string`. There is no folder nesting; all files are flat in a single directory, with dots encoding the tree structure. Lookup uses Fuse.js fuzzy search over filenames, so typing "py str" finds `lang.python.data.string.md`.
+
+**Dendron schema format:**
+
+```yaml
+version: 1
+schemas:
+  - id: daily
+    pattern: daily
+    children:
+      - pattern: journal
+        children:
+          - pattern: "*"
+            template:
+              id: templates.daily
+              type: note
+```
+
+Schemas enforce structure on note creation. When you create a note matching `daily.journal.*`, Dendron automatically applies the `templates.daily` template. This is the closest thing to "types" in the Zettelkasten world — it gives you consistent structure without abandoning the flat-file model.
+
+**Foam's graph model:** The `FoamGraph` class maintains two Maps: `links` (outgoing references from each note) and `backlinks` (incoming references to each note). The graph undergoes a full rebuild on every workspace change — clear all links, then re-walk all resources to reconstruct the graph. Foam uses a `TrieMap` for prefix-based lookup, which enables efficient "find all notes starting with X" queries.
+
+**note-link-janitor algorithm** (Andy Matuschak, approximately 200 lines total):
+
+1. Scan all `.md` files, parse wiki-links via remark AST
+2. Build `Map<targetTitle, Map<sourceTitle, contextBlocks>>` — for each target note, collect all source notes that link to it along with the surrounding context
+3. Compute PageRank over the link graph to determine note importance
+4. Write a `## Backlinks` section into each file, sorted by PageRank — the most important referring notes appear first
+
+This is a batch process, not live — you run it periodically to update backlinks across the entire wiki.
+
+**Scale:** Fuse.js threshold bugs appear above approximately 10,000 notes in Dendron — fuzzy matching starts returning irrelevant results or missing relevant ones. Foam's full graph rebuild is O(N*L) where N is the number of notes and L is the average number of links per note. The note-link-janitor is batch-only and works well to approximately 10,000 notes; beyond that, memory consumption during the full-graph PageRank computation becomes an issue.
+
+## 3. PARA (Tiago Forte)
+
+**Core idea:** Four categories organized by actionability, not topic: Projects (active work with deadlines), Areas (ongoing responsibilities without end dates), Resources (reference material for future use), Archive (inactive items from any of the other three categories).
+
+**Folder structure:**
+
+```
+1 - projects/    # Active, with deadlines
+2 - areas/       # Ongoing responsibilities
+3 - resources/   # Topic-based reference material
+4 - references/  # External reference material
+5 - archives/    # Inactive items from any category
+```
+
+The numbered prefixes enforce sort order. The critical distinction is between Projects (finite, with a clear completion state) and Areas (infinite, maintained indefinitely). A course you are teaching this semester is a Project; "teaching" as a professional responsibility is an Area.
+
+**At scale:** PARA has no built-in cross-referencing mechanism — it relies entirely on whatever the host tool provides (Obsidian backlinks, Notion relations, etc.). Manual reclassification becomes the primary bottleneck past approximately 200 items. When a project ends, you must manually move it to Archive, and any Resources it spawned must be manually relocated. The `para-shortcuts` Obsidian plugin automates moves between categories with hotkeys, but no automated classification tooling exists at any level of maturity.
+
+**Relevance to us:** Our Google Drive structure (`00-course`, `01-formal`, `02-lectures`, etc.) is already partially PARA — `02-lectures` maps to Projects (each lecture is a deliverable with a deadline), `04-resources` maps to Resources, and `archive/` maps to Archive. But PARA alone cannot handle thousands of papers or cross-reference requirements across lectures. It provides a top-level organizational frame, not a knowledge retrieval system.
+
+## 4. Johnny Decimal
+
+**Core idea:** Strict numeric hierarchy with three levels: Areas (X0-X9), Categories (XY), and IDs (XY.ZZ). This creates a hard ceiling: 10 areas times 10 categories times 100 IDs = 10,000 items maximum.
+
+**Structure:**
+
+```
+00-09 System/
+  01 System Stuff/
+    01.02 A Name.md
+10-19 Project Management/
+  11 Planning/
+    11.01 Roadmap.md
+```
+
+The JDex (index) is a plain-text file mapping every ID to a human-readable description. The `jdlint` tool validates that the file system matches the JDex and that no IDs are duplicated or out of range. When you exceed 10 areas, the official guidance is to create entirely separate JD systems rather than extending the numbering.
+
+The discipline is the point. You cannot have more than 10 top-level areas, which forces you to think carefully about categorization. Each item gets exactly one location — there is no tagging, no cross-referencing, no "this belongs in two places." If you need to reference something from multiple contexts, you use the numeric ID as a pointer.
+
+**Relevance:** Our `lec-01..lec-17` and `sem-01..sem-17` numbering is proto-Johnny Decimal. The numeric discipline works well for stable, bounded collections (17 lectures, 17 seminars) where the total count is known in advance. It breaks down for open-ended collections like research papers, notes, and references that grow without a predetermined ceiling.
+
+## 5. Digital Garden (Andy Matuschak)
+
+**Core idea:** Evergreen notes that evolve over time. Flat structure, dense links, backlinks maintained automatically. The philosophy is "work with the garage door up" — publish notes in progress, let them grow organically, revise them as understanding deepens.
+
+The key principle is anti-transience: notes are not dated blog posts that become stale but living documents that get revised whenever new information arrives. A note on "transformer attention mechanisms" written in 2023 should be updated in 2026 with new findings, not replaced by a new note.
+
+The note-link-janitor (described in section 2 above) is the primary maintenance tool, keeping backlinks current with PageRank-sorted context so the most important connections surface first.
+
+**At scale:** Large Obsidian vaults demonstrate that flat structure breaks above approximately 200 notes — navigation becomes unmanageable without some grouping. The nolebase vault (484 files) uses category folders with co-located assets (images stored alongside the notes that reference them), NOT flat structure. Maps of Content (MOCs) serve as manually curated index pages that group related notes by theme — essentially a human-maintained version of Karpathy's `index.md`.
+
+The tension between "flat is pure" and "folders are practical" is the central scaling challenge. Most gardens that grow beyond 200 notes adopt a pragmatic hybrid: broad category folders (5-10 at most) with flat structure within each folder.
+
+## 6. Docs-as-Code (Kubernetes, Docusaurus)
+
+**Core idea:** Documentation lives in version control alongside code, written in markdown, rendered by static site generators. Content types are formalized with templates and build-time validation.
+
+**Kubernetes content types:**
+
+- `concept` — "What is X?" explanations of system components and abstractions
+- `task` — "How to do X" step-by-step procedures for specific goals
+- `tutorial` — End-to-end walkthroughs combining multiple tasks into a complete scenario
+- `reference` — API specifications, CLI documentation, configuration schemas
+
+Each content type has a Hugo archetype (template) that enforces required sections. A `task` page must have Prerequisites, Steps, and Verification sections. A `concept` page must have Overview, How It Works, and What's Next sections. This structural consistency is what makes the documentation navigable at scale.
+
+**Cross-references use build-time validated shortcodes:**
+
+```
+glossary_tooltip term_id="cluster"
+```
+
+An invalid `term_id` halts the build. This means broken cross-references are caught before publication, not discovered by readers. The glossary is a YAML file mapping term IDs to definitions, and every shortcode reference is validated against it.
+
+**Docusaurus sidebar auto-generation:** Number prefix parsing strips `01-intro.md` down to position 1 with slug "intro". The `_category_.json` file in each directory provides category metadata (label, position, collapsibility). This convention-over-configuration approach means the sidebar structure mirrors the file system structure — no separate configuration file to maintain.
+
+**At 3000+ pages:** Build times stretch to approximately 3 minutes. The glossary validation system catches broken links at build time but adds to that build duration. Versioning is the real scaling challenge: Kubernetes duplicates entire doc trees per version, so 500 documents across 10 supported versions means 5,000 files in the repository. Each file must be independently maintained when cross-version changes occur.
+
+## 7. LLM-Native Retrieval
+
+This is not a separate organizational approach but a retrieval strategy that changes how you think about organization. The key principles:
+
+**The LLM reads structured markdown and navigates by index.** Unlike keyword search or vector similarity, an LLM can understand what a document is about from its title, headings, and a one-line summary. A good index turns the LLM into a librarian who knows the entire collection.
+
+**At moderate scale (up to approximately 200 pages), context windows replace RAG.** If your index fits in context — and with 200,000-token context windows, an index of 200 pages with titles and summaries easily fits — the LLM can find anything without vector search. Retrieval is precise because the LLM understands the query semantically.
+
+**At large scale (1000+ pages), hierarchical indexes with vector search and graph traversal combine.** The index becomes multi-level: a top-level index points to section indexes, which point to individual pages. Vector search handles "find me something similar to X" queries that hierarchical navigation cannot. Graph traversal handles "what else is related to this concept" queries that neither index scanning nor vector search handle well.
+
+**"Vibe coding" produces custom tools as throwaway infrastructure.** Need a script to extract all cross-references from 500 markdown files and build a link graph? An LLM writes it in 5 minutes. The script is not maintained software — it is disposable tooling generated on demand.
+
+**Knowledge compounds: every interaction adds to the wiki.** When you ask the LLM a question and it synthesizes an answer from multiple sources, that synthesis becomes a new wiki page. The knowledge base grows not just from explicit ingestion but from the act of using it.
+
+## Comparison Matrix
+
+| Approach | Organization | Cross-refs | Scale Limit | Best For |
+|----------|-------------|------------|-------------|----------|
+| Karpathy Wiki | 3-layer (raw/wiki/schema) | LLM-generated | ~500 before RAG needed | Solo researcher, LLM-native |
+| Zettelkasten | Flat + links (or dot-hierarchy) | Bidirectional wiki-links | ~10k (Fuse.js limits) | Deep thinkers, long-term KB |
+| PARA | 4 folders by actionability | Tool-dependent | ~200 before reclassification pain | Action-oriented individuals |
+| Johnny Decimal | Strict numeric hierarchy | Numeric IDs | 10,000 hard cap | Bounded, stable collections |
+| Digital Garden | Flat + dense links | Backlinks + MOCs | ~500 flat, more with folders | Writers, public intellectuals |
+| Docs-as-Code | Content-type hierarchy | Build-time validation | 3000+ (with build cost) | Teams, open source projects |
+| LLM-Native | Hierarchical indexes | Auto-generated | Depends on retrieval stack | Any scale, with right retrieval |
+
+The approaches are not mutually exclusive. Most real systems combine elements: PARA-style top-level folders with Zettelkasten-style links within them, or Docs-as-Code structure with LLM-native retrieval layered on top. The question is not which approach to choose but which combination matches your scale, team size, and tooling.
+
+> Continue to [Part 2: Retrieval Strategies Compared](knowledge-architecture-comparison-part2.md)

--- a/notes/research/knowledge-architecture-comparison-part2.md
+++ b/notes/research/knowledge-architecture-comparison-part2.md
@@ -1,0 +1,156 @@
+---
+title: "Knowledge Architecture for LLM-Native Workflows: Retrieval Strategies"
+part: 2
+parts_total: 3
+description: "Part 2: Four retrieval strategies compared — grep, vector search, SPARQL, and hybrid — with benchmarks and production examples"
+issue: "#18"
+epic: "#17"
+date: 2026-04-07
+---
+
+# Retrieval Strategies Compared
+
+> Part 2 of 3: From Grep to Hybrid RAG
+> See also: [Part 1 — Seven Approaches](knowledge-architecture-comparison-part1.md) | [Part 3 — Our Architecture](knowledge-architecture-comparison-part3.md)
+
+## 1. Naive Grep (Keyword/Regex Search)
+
+**How it works:** Pattern matching over raw text. Tools: ripgrep, ag, grep. SIMD-optimized, scans 16-32 bytes per CPU cycle using finite automata.
+
+**Performance numbers:**
+- ripgrep on 1.4GB monorepo (250K files): under 1 second
+- 240 log files: grep 4.2s, ripgrep 0.018s (233x speedup)
+- Hits limits at ~1M files (15+ seconds)
+- Cursor's indexed search: 0.013s where ripgrep took 15s on same repo
+
+**When grep wins over vector search:**
+- Exact matches: error codes, UUIDs, config keys, function names
+- Structured data and code: regex over JSON, logs, source
+- Zero infrastructure, zero index maintenance
+
+**When it fails:** Semantic queries ("find notes about motivation" won't match "drive" or "ambition"), synonyms, multilingual content, relevance ranking.
+
+**Crossover point:** If you search the same corpus repeatedly, build an index; grep is faster for ad-hoc searches up to ~500K files.
+
+## 2. Vector/Embedding Semantic Search
+
+**How it works:** Text -> high-dimensional vectors via embedding models. Nearest-neighbor search in vector space. Tools: LanceDB, Pinecone, Chroma, pgvector.
+
+**Cost profile:**
+- Embedding: ~$0.10 per 1M tokens (ada-002)
+- Storage: ~1.5KB per vector (1536 dims)
+- Query: sub-millisecond with HNSW indices at 1M vectors
+- Managed service: ~$70/month per 1M vectors (Pinecone)
+
+**When it excels:** Synonyms, paraphrases, cross-language matching ("scarlet biker coat" matches "red leather jacket"), conceptual queries, unknown terminology.
+
+**When it fails:**
+- Exact-match queries (ERROR_4532 vs ERROR_4533 map to near-identical vectors)
+- Structured/relational queries ("which doc cites X")
+- Explainability (similarity scores don't explain WHY)
+- Small corpora (overkill -- more infrastructure than value)
+
+**Hybrid BM25+Vector:** OpenSearch 3.x combines BM25 keyword scoring with vector search. Their hybrid bulk scorer: 65% faster than running both separately, additional 20% in v3.3.
+
+## 3. Ontology/SPARQL (Graph Traversal)
+
+**How it works:** Knowledge modeled as entities + relationships (RDF triples). Queries traverse the graph using SPARQL, following explicit typed relationships.
+
+**Engine benchmarks:**
+- Oxigraph: 35M triples tested, SPARQL queries ~20ms in-memory, suitable for small-to-medium datasets
+- Wikidata: 16 billion triples on Blazegraph (hitting limits, migrating)
+- QLever: claims 1 trillion+ triples on commodity hardware
+- Virtuoso: enterprise-grade, handles billions
+
+**When SPARQL outperforms vector search:**
+- Multi-hop queries: "Papers citing Author X published in Venue Y" -- graph traversal, not similarity
+- Provenance chains: "Requirement -> test case -> coverage" -- explicit typed relationships
+- Aggregation with constraints: COUNT, FILTER, negation -- impossible with similarity search
+- Negation: "Which entities do NOT have relationship R?"
+
+**When it fails:** Unstructured content (must extract entities first), fuzzy/exploratory queries, cold-start (significant upfront ontology design).
+
+## 4. Hybrid Retrieval (Production Patterns)
+
+### HybridRAG (NVIDIA/BlackRock)
+Two parallel channels: VectorRAG (embed chunks, cosine similarity) + GraphRAG (entity extraction, graph traversal). Both results concatenated before LLM generation. Tested on financial earnings transcripts. Outperforms both individual approaches on retrieval accuracy and answer quality.
+
+### Microsoft GraphRAG
+LLM-based graph construction -> Leiden community detection -> hierarchical summarization.
+
+Scale: Podcast corpus (1M tokens) -> 8,564 nodes, 20,691 edges -> 34 root communities -> 367 at C1 -> 969 at C2 -> 1,310 leaf communities.
+
+Quantitative vs naive vector RAG:
+- Comprehensiveness win rate: 72-83%
+- Diversity win rate: 75-82%
+- Claims per answer: 31-34 vs 25-27
+- Token efficiency: root summaries used 2.6% of max context (9-43x reduction)
+
+Cost: Graph indexing for 1M tokens took 281 minutes with GPT-4-turbo. This is the main drawback -- LLM-expensive indexing.
+
+Key difference: Naive RAG retrieves similar chunks. GraphRAG answers "global sensemaking" questions requiring synthesis across the entire corpus.
+
+### Reciprocal Rank Fusion (RRF)
+Standard merging technique: each strategy produces ranked list, RRF computes `1/(k + rank)`, sums across lists. Simple, parameter-light, consistently outperforms learned fusion.
+
+### Production Systems
+- **Glean:** vector + BM25 + organizational knowledge graph (permissions, ownership, reporting structure)
+- **Neo4j + Pinecone:** vector search -> entity extraction -> graph enrichment -> merged context for LLM
+- **Semantic Scholar:** papers + citations graph + semantic similarity
+
+### Cost of a 3-Strategy System
+- Vector DB: ~$70/month per 1M vectors
+- Graph DB: ~$65/month for 200K nodes / 400K relationships
+- BM25 index: ~$50/month managed
+- Embedding computation: ~$0.10 per 1M tokens one-time
+- Graph extraction: periodic LLM re-runs as docs change
+
+## Comparison Matrix
+
+| Strategy | Best For | Scale Limit | Latency | Index Cost |
+|----------|----------|-------------|---------|------------|
+| BM25/grep | Exact terms, code, structured data | Unlimited (streaming) | <1s to 100K files | Zero |
+| Vector search | Semantic similarity, paraphrase | Billions (managed) | 10-100ms at 1M | $0.10/1M tokens |
+| SPARQL/KG | Multi-hop, provenance, aggregation | 35M (Oxigraph), 1T+ (QLever) | 20-750ms/query | High (extraction) |
+| GraphRAG | Global sensemaking, themes | ~2M tokens practical | Seconds (map-reduce) | $$$ (LLM indexing) |
+| Hybrid (RRF) | Diverse queries, robustness | Sum of components | Max of components | Sum of components |
+
+## Key Insight: No Single Strategy Suffices at Scale
+
+At 27 documents, grep + a good index might be enough.
+At 1,000+ sources, you need at minimum: structured index (navigation) + vector search (discovery) + graph (relationships).
+At 10,000+, add GraphRAG-style community summaries for global sensemaking.
+
+The question is not "which strategy?" but "how do you tier them?"
+
+```
+Query
+  |
+  v
+Tier 1: Wiki Index (navigate structured pages, near-zero cost)
+  |
+  v
+Tier 2: Ontology SPARQL (follow typed relationships, dependencies)
+  |
+  v
+Tier 3: Vector Search (semantic discovery, fuzzy matching)
+  |
+  v
+Tier 4: Full-text grep (exact match fallback, precision)
+  |
+  v
+Merge via RRF --> Answer with provenance
+```
+
+## References
+
+- [HybridRAG paper](https://arxiv.org/abs/2408.04948) -- NVIDIA/BlackRock, August 2024
+- [Microsoft GraphRAG](https://arxiv.org/html/2404.16130v2) -- Edge et al., April 2024
+- [Oxigraph benchmarks](https://github.com/oxigraph/oxigraph/blob/main/bench/README.md)
+- [ripgrep benchmarks](https://burntsushi.net/ripgrep/)
+- [OpenSearch hybrid search](https://opensearch.org/blog/opensearch-3-3-performance-innovations-for-ai-search-solutions/)
+- [Pinecone + Neo4j](https://www.pinecone.io/learn/vectors-and-graphs-better-together/)
+- [Wikidata SPARQL scaling](https://www.wikidata.org/wiki/Wikidata:SPARQL_query_service/WDQS_backend_update/August_2021_scaling_update)
+- [QLever engine](https://github.com/ad-freiburg/qlever)
+
+> Continue to [Part 3: Our Architecture -- Designing for 1000+ Sources](knowledge-architecture-comparison-part3.md)

--- a/notes/research/knowledge-architecture-comparison-part3.md
+++ b/notes/research/knowledge-architecture-comparison-part3.md
@@ -1,0 +1,230 @@
+---
+title: "Knowledge Architecture for LLM-Native Workflows: Our Design"
+part: 3
+parts_total: 3
+description: "Part 3: Designing a knowledge architecture for 1000+ sources — combining Karpathy's wiki pattern with ontology graphs and hybrid retrieval"
+issue: "#18"
+epic: "#17"
+date: 2026-04-07
+---
+
+# Our Architecture: Designing for 1000+ Sources
+
+> Part 3 of 3: From Research to Implementation
+> See also: [Part 1 — Seven Approaches](knowledge-architecture-comparison-part1.md) | [Part 2 — Retrieval Strategies](knowledge-architecture-comparison-part2.md)
+
+## Starting Point
+
+We run a course-delivery and knowledge-management system built entirely on Claude Code as the runtime. Current state:
+- 27 cataloged documents (Google Docs, Sheets, Slides)
+- RDF ontology with 8 entity types, 7 relation types (Oxigraph via open-ontologies MCP)
+- LanceDB vector store with 2-4 documents ingested
+- 6 MCP servers (workspace-mcp, github, document-loader, local-rag, drawio, open-ontologies)
+- Target: **thousands of sources and papers**
+
+## What We Learned from the Research
+
+### From Karpathy's LLM Wiki
+- The 3-layer pattern (raw/wiki/schema) is the right foundation
+- Compilation (raw -> wiki pages) is the key operation, not manual curation
+- Index-first retrieval works up to ~500 sources — beyond that, you need vector search
+- Concept extraction (auto-discovering cross-cutting themes) is more valuable than per-document summaries
+- Coverage indicators (high/medium/low) tell users when to trust the wiki vs go to raw sources
+- Incremental compilation (only recompile changed topics) is essential for maintainability
+
+### From Zettelkasten/Dendron
+- Dot-separated naming (or hierarchical folders) scales better than flat files
+- Bidirectional links with backlink sections create navigable knowledge webs
+- PageRank-sorted backlinks surface the most important connections
+- Schemas/templates enforce consistency at scale
+
+### From Docs-as-Code
+- Formal content types (concept, task, reference) help both humans and LLMs navigate
+- Build-time validation of cross-references catches broken links early
+- Number-prefixed files provide deterministic ordering
+- At 3000+ pages, build/compilation time becomes a real constraint
+
+### From Johnny Decimal
+- Numeric discipline is great for bounded, stable collections (lectures, seminars)
+- But the 10x10 limit makes it unsuitable for open-ended collections (papers, research notes)
+- The JDex (index file) pattern is useful even without the full numbering system
+
+### What Breaks at Scale
+- Flat folder structures collapse at ~200 files
+- Single index files exceed 600 lines at ~300 sources
+- Full graph rebuilds (Foam-style) become expensive at 1000+ linked notes
+- Manual cross-referencing is unsustainable past ~50 documents
+- PARA reclassification becomes a bottleneck past ~200 items
+
+## Proposed Architecture
+
+### Three Layers (Karpathy-adapted)
+
+```
+CLAUDE.md              -- Schema layer: conventions, content types, cross-ref rules
+raw/                   -- Source layer: immutable inputs
+  exports/             -- Google Drive exports (markdown, from workspace-mcp)
+  papers/              -- PDFs, external papers (from document-loader MCP)
+    by-topic/          -- Topic-based organization
+  research/            -- Research notes (moved from notes/research/)
+wiki/                  -- Wiki layer: LLM-compiled, auto-maintained
+  index.md             -- Master index (taxonomy navigator, not full listing)
+  topics/              -- Hierarchical topic pages
+    ai-ethics/
+      _index.md        -- Topic overview + sub-topic listing
+      bias-fairness.md -- Sub-topic page
+      ...
+    prompt-engineering/
+      _index.md
+      ...
+  lectures/            -- One summary per lecture (17 total)
+    lec-01.md
+    ...
+  documents/           -- One summary per cataloged document
+  concepts/            -- Cross-cutting concept pages (auto-discovered)
+  glossary.md          -- Terms and definitions
+```
+
+### Content Types
+
+| Type | Location | Template | Growth Pattern |
+|------|----------|----------|----------------|
+| Topic index | `wiki/topics/{topic}/_index.md` | topic-index.md | Splits into sub-topics when >100 sources |
+| Topic page | `wiki/topics/{topic}/{subtopic}.md` | topic-page.md | One per sub-topic |
+| Lecture summary | `wiki/lectures/lec-NN.md` | lecture-summary.md | Fixed at 17 |
+| Document summary | `wiki/documents/{slug}.md` | document-summary.md | Grows to thousands |
+| Concept page | `wiki/concepts/{concept}.md` | concept-page.md | Auto-discovered, grows organically |
+| Paper note | `wiki/papers/{slug}.md` | paper-note.md | Grows to thousands |
+| Decision record | `notes/decisions/{slug}.md` | decision-record.md | Low volume, stable |
+| Reflection | `notes/reflections/{date}-{topic}.md` | reflection.md | Session-based |
+
+Each type has YAML frontmatter with: title, type, topics (list), sources (list), status, coverage (high/medium/low), updated_at.
+
+### Hierarchical Index Design
+
+At 1000+ sources, a single `index.md` won't work. The index is a **tree**:
+
+```
+wiki/index.md                           -- Master: 17 topic clusters with counts
+  -> wiki/topics/ai-ethics/_index.md    -- Topic: 47 sources, 5 sub-topics
+    -> wiki/topics/ai-ethics/bias.md    -- Sub-topic: 12 sources detailed
+```
+
+Master index entry format:
+```markdown
+## AI Ethics (47 sources, 5 sub-topics)
+Core questions: bias detection, fairness metrics, regulatory compliance, transparency, accountability
+Lectures: 14, 15 | Key papers: [Smith2024], [EU-AI-Act]
+-> [Full topic index](topics/ai-ethics/_index.md)
+```
+
+Auto-split rule: when a topic index exceeds 300 lines, spawn sub-topic pages.
+
+### 4-Tier Retrieval Pipeline
+
+```
+Query --> Intent Classification
+  |
+  |--> Navigational ("show me lecture 5") --> Tier 1: Wiki Index
+  |--> Relational ("what depends on RPD?") --> Tier 2: Ontology SPARQL
+  |--> Semantic ("papers about fairness") --> Tier 3: Vector Search
+  |--> Exact ("find ERROR_4532") --> Tier 4: Grep
+  |
+  v
+Merge via RRF --> Answer with provenance (which tier found what)
+```
+
+**Tier 1 — Wiki Index:** Read master index, drill into topic/lecture pages. Near-zero cost. Handles: navigation, "everything about X", overview queries.
+
+**Tier 2 — Ontology SPARQL:** Traverse typed relationships. Handles: dependencies ("what does Lecture 3 depend on?"), impact analysis ("if RPD changes, what breaks?"), provenance ("where does this requirement come from?"). Extended ontology with hierarchical topic taxonomy.
+
+**Tier 3 — Vector Search:** LanceDB embeddings over all wiki + raw content. Handles: fuzzy/conceptual discovery, synonym matching, "find similar papers". This is a CORE tier at 1000+ sources, not a fallback.
+
+**Tier 4 — Full-text Grep:** ripgrep for exact matches. Handles: specific IDs, error codes, exact phrases, proper names.
+
+### Compilation Pipeline (Skill: /compile-wiki)
+
+Inspired by sage-wiki's 5-pass pipeline, adapted for Claude Code + MCP:
+
+1. **Diff:** Compare raw/ against wiki manifest (content hashes). Identify added/modified/removed sources.
+2. **Summarize:** Subagent reads new/changed raw sources, generates summaries.
+3. **Extract concepts:** Identify cross-cutting concepts spanning 3+ topics. Merge with existing concepts.
+4. **Compile pages:** Generate/update wiki pages per topic, lecture, document, concept. Include coverage indicators.
+5. **Link & index:** Generate cross-links, backlinks, update hierarchical indexes. Validate all links.
+
+Incremental: only recompile topics whose sources changed. Full recompile on schema changes.
+
+### Ontology Extension
+
+Current: 8 entity types, 7 relations, ~20 instances.
+Target: hierarchical topic taxonomy, thousands of entity instances, rich cross-references.
+
+New entity types:
+- `aul:Paper` — external academic paper
+- `aul:Concept` — cross-cutting concept (auto-discovered)
+- `aul:SubTopic` — sub-topic within a topic hierarchy
+
+New relations:
+- `aul:subtopic_of` — topic hierarchy
+- `aul:cites_paper` — document/lecture references a paper
+- `aul:related_concept` — concept-to-concept links
+
+### Migration from Current State
+
+Phase 1: Restructure (no content changes)
+- Create wiki/, raw/ directories
+- Move catalog/exports/docs/ -> raw/exports/
+- Move notes/research/ -> raw/research/
+- Reorganize notes/ into decisions/, reflections/
+- Update CLAUDE.md, manifests, skills
+
+Phase 2: Initial compilation
+- Compile wiki pages from existing 27 documents
+- Generate master index + topic indexes
+- Populate ontology with all instances and relations
+- Ingest everything into RAG
+
+Phase 3: Scale preparation
+- Create bulk import workflow for papers
+- Test with 100 papers
+- Validate hierarchical index auto-splitting
+- Benchmark 4-tier retrieval
+
+## What This Does NOT Include (Intentional Simplifications)
+
+- No custom web UI — Claude Code is the only interface
+- No real-time sync — compilation is triggered manually or by skill
+- No multi-user access control — single maintainer
+- No GraphRAG-style LLM community detection — too expensive for our budget, revisit later
+- No automated paper discovery/crawling — manual import, then auto-processing
+
+## Self-Roast (Pre-Implementation)
+
+**Risk: Over-engineering.** 4 tiers, 5-pass pipeline, hierarchical indexes — is this simpler than what we have? Counter: what we have doesn't work at all for "find me everything about X." The complexity is earned.
+
+**Risk: Wiki goes stale.** If compilation isn't triggered regularly, wiki diverges from raw sources. Mitigation: coverage indicators show staleness; /compile-wiki integrated into daily cycle.
+
+**Risk: Ontology cold-start.** Populating thousands of entities is expensive. Mitigation: auto-extract from wiki compilation, not manual entry.
+
+**Risk: LanceDB at thousands of docs.** Current setup has 2-4 docs. Will bulk ingestion work? Mitigation: test with 100 papers in Phase 3 before committing.
+
+**Risk: 600-line limit creates too many small files.** At 1000 sources with topic pages, sub-topic pages, concept pages — we could have 500+ wiki files. Counter: that's the point. Many small, focused files > few huge files. The index tree makes them navigable.
+
+## Next Steps
+
+1. **#19** — Finalize this design with user feedback
+2. **#20** — Define 3 test scenarios against current system
+3. **#21** — Implement folder structure + initial compilation
+4. **#22** — Implement 4-tier retrieval pipeline
+5. **#23** — Run tests, compare before/after
+6. **#24** — Roast, improve, update blueprint
+
+## References
+
+- Karpathy LLM Wiki pattern — [gist](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)
+- sage-wiki 5-pass pipeline — [GitHub](https://github.com/xoai/sage-wiki)
+- ussumant/llm-wiki-compiler — coverage indicators, 81x compression
+- Dendron dot-hierarchy — [GitHub](https://github.com/dendronhq/dendron)
+- Kubernetes content types — [content guide](https://kubernetes.io/docs/contribute/style/content-guide/)
+- HybridRAG — [arXiv 2408.04948](https://arxiv.org/abs/2408.04948)
+- Microsoft GraphRAG — [arXiv 2404.16130](https://arxiv.org/html/2404.16130v2)

--- a/notes/research/knowledge-architecture-raw-research-part1.md
+++ b/notes/research/knowledge-architecture-raw-research-part1.md
@@ -1,0 +1,276 @@
+---
+title: "Extended Research: Knowledge Architecture — Raw Findings (Part 1)"
+description: "Internal reference: full code snippets, algorithms, and implementation details from Karpathy wiki implementations and Zettelkasten tools"
+issue: "#18"
+epic: "#17"
+date: 2026-04-07
+type: research-note
+---
+
+# Extended Research: Raw Findings (Part 1 of 2)
+
+> Internal reference document. For the polished version, see [blog post parts 1-3](knowledge-architecture-comparison-part1.md).
+> See also: [Part 2 — Retrieval and Scale](knowledge-architecture-raw-research-part2.md)
+
+## Karpathy LLM Wiki — Implementation Deep-Dive
+
+### The Gist (Original Specification)
+
+Three-layer architecture with two supporting files and three operations.
+
+**Layers:**
+- `raw/` — immutable source documents. "The LLM reads from them but never modifies them. This is your source of truth."
+- `wiki/` — LLM-generated markdown. "Summaries, entity pages, concept pages, comparisons, an overview, a synthesis."
+- Schema document (CLAUDE.md) — defines folder structure, citation rules, ingest workflow, Q&A behavior, linting conventions.
+
+**Supporting files:**
+- `index.md` — "A catalog of everything in the wiki — each page listed with a link, a one-line summary." Organized by category.
+- `log.md` — "An append-only record of what happened and when — ingests, queries, lint passes."
+
+**Operations:**
+1. **Ingest** — reads source, discusses takeaways, writes summary page, updates index, updates 10-15 related pages
+2. **Query** — searches wiki pages to synthesize answers. Good answers filed back as new pages.
+3. **Lint** — health-check: contradictions, orphan pages, stale claims, missing concepts.
+
+**Scale quotes (Karpathy):**
+- "At ~100 articles and ~400K words, the LLM's ability to navigate via summaries and index files is more than sufficient."
+- "For a departmental wiki or personal research project, 'fancy RAG' infrastructure often introduces more latency and retrieval noise than it solves."
+- "The index itself becomes too large to fit in context" beyond a few hundred articles — recommends `qmd` CLI search.
+
+### ussumant/llm-wiki-compiler (Claude Code Plugin)
+
+**Plugin structure:**
+```
+plugin/
+  .claude-plugin
+  commands/       # /wiki-init, /wiki-compile, /wiki-lint, /wiki-query, /wiki-upgrade
+  hooks/          # SessionStart hook injects wiki context
+  skills/
+    wiki-compiler # main skill
+  templates/
+    schema-template.md
+    article-template.md
+    index-template.md
+```
+
+**Schema template defines:**
+- Topics (slug + description)
+- Concepts (cross-cutting patterns spanning 3+ topics)
+- Article structure: Summary, Timeline, Current State, Key Decisions, Experiments, Gotchas, Open Questions, Sources
+- Naming conventions: lowercase-kebab-case
+- Cross-reference rules
+- Evolution log for schema changes
+
+**Article template with coverage indicators:**
+```markdown
+---
+topic: {topic-slug}
+last_compiled: {ISO-date}
+source_count: {N}
+status: {draft|compiled|reviewed}
+---
+## Summary [coverage: high -- 15 sources]
+...
+## Experiments & Results [coverage: medium -- 3 sources]
+...
+## Gotchas [coverage: low -- 1 source]
+...
+```
+
+Coverage meaning:
+- high (5+ sources) — trust wiki, skip raw
+- medium (2-4 sources) — wiki is good, check raw for detail
+- low (0-1 sources) — read raw directly
+
+**Compression metrics:**
+- 383 files (13.1 MB) -> 13 articles (161 KB) = 81x compression
+- 130 meeting transcripts (122,625 lines) -> 1 digest (244 lines) = 503x compression
+- Session startup: ~47K tokens -> ~7.7K tokens = 84% reduction
+
+**Three adoption modes:** staging (wiki on demand), recommended (wiki before raw), primary (wiki is source)
+
+**Concept articles:** Auto-discovered cross-cutting patterns spanning 3+ topics. Example: "Speed vs Quality Tradeoff" found across 6 instances in retention, push notifications, experiment design.
+
+**Incremental compilation:** After first full compile, only topics with changed source files recompile. INDEX.md always regenerated.
+
+### atomicmemory/llm-wiki-compiler (TypeScript + Anthropic API)
+
+**Source structure:**
+```
+src/
+  compiler/
+    index.ts        # orchestration
+    prompts.ts      # LLM prompt templates
+    indexgen.ts      # wiki/index.md generator
+    deps.ts          # dependency graph
+    hasher.ts        # content hashing for incremental
+    orphan.ts        # orphan page detection
+    resolver.ts      # cross-reference resolution
+  ingest/
+  utils/
+```
+
+**Phase 1 — Concept Extraction (tool_use mode):**
+```typescript
+CONCEPT_EXTRACTION_TOOL = {
+  name: "extract_concepts",
+  input_schema: {
+    concepts: [{
+      concept: "string",   // Human-readable title
+      summary: "string",   // One-line description
+      is_new: "boolean"    // Not in existing wiki?
+    }]
+  }
+}
+```
+
+System prompt: "Analyze the following source document and identify 3-8 distinct, meaningful concepts worth documenting as wiki pages. Focus on key ideas, techniques, patterns, or entities — not trivial details."
+
+**Phase 2 — Page Generation:**
+```typescript
+buildPagePrompt(concept, sourceContent, existingPage, relatedPages)
+// "Write a clear, well-structured markdown page about {concept}."
+// "Draw facts only from the provided source material."
+// "Include a ## Sources section. Suggest [[wikilinks]] to related concepts."
+```
+
+**Index generation (indexgen.ts):** Scans `wiki/concepts/` for `.md` files, extracts YAML frontmatter (title, summary), produces sorted list: `- **[[Title]]** — summary`.
+
+**Cross-references:** `resolver.ts` handles wikilink resolution; `deps.ts` builds dependency graph; `orphan.ts` detects pages whose sources were deleted.
+
+### xoai/sage-wiki (Go, Production-Grade)
+
+**Internal structure:**
+```
+internal/
+  compiler/      # pipeline.go, concepts.go, diff.go, summarize.go, write.go, watch.go
+  embed/         # embedding providers
+  extract/       # PDF, DOCX, XLSX, EPUB, images
+  hybrid/        # BM25 + vector hybrid search
+  manifest/      # .manifest.json tracking source hashes
+  mcp/           # MCP server for agent integration
+  memory/        # compilation learnings store
+  ontology/      # concept graph
+  prompts/templates/   # summarize_article.txt, extract_concepts.txt, write_article.txt
+  storage/       # SQLite DB
+  vectors/       # vector store
+```
+
+**5-Pass Compilation Pipeline:**
+1. **Diff** — compare source files against `.manifest.json` (content hashes). Categorize: Added/Modified/Removed.
+2. **Summarize** — LLM summarizes each new/changed source (separate prompts for articles vs papers).
+3. **Extract concepts** — from summaries, identify concepts with aliases, merge with existing.
+4. **Write articles** — generate/update wiki pages per concept, with related concepts and existing article as context.
+5. **Post** — auto-embed (vectors), auto-lint, auto-commit (git).
+
+**Checkpoint/resume:** `CompileState` struct tracks `compile_id`, `pass`, `completed`, `pending`, `failed`. Supports resuming interrupted compilations.
+
+**Scale features:**
+- `max_parallel: 4` concurrent LLM calls
+- Content hashing via manifest for incremental
+- Hybrid search: `hybrid_weight_bm25: 0.7` / `hybrid_weight_vector: 0.3`
+- Watch mode with debounce (`debounce_seconds: 2`)
+- Per-task model selection (cheap for summarize, quality for write)
+
+**Extract concepts prompt:**
+```
+Given summaries of recently added/modified sources, extract concepts.
+For each: name (lowercase-hyphenated), aliases, sources, type (concept/technique/claim).
+Merge with existing concepts when appropriate (detect aliases).
+Output as JSON array.
+```
+
+**Write article prompt:**
+```
+Write structured wiki article with sections:
+## Definition, ## How it works, ## Variants, ## Trade-offs, ## See also
+YAML frontmatter: concept, aliases, sources, related, confidence
+```
+
+## Zettelkasten Tools — Implementation Details
+
+### Dendron: Hierarchy as Index
+
+**FuseEngine lookup (packages/common-all/src/FuseEngine.ts):**
+```typescript
+const options: Fuse.IFuseOptions<T> = {
+  shouldSort: true,
+  threshold: opts.threshold,    // 0.0 exact, ~0.2 fuzzy
+  distance: 15,
+  minMatchCharLength: 1,
+  keys: ["fname"],              // dot-separated filename
+  useExtendedSearch: true,
+  includeScore: true,
+  ignoreLocation: true,
+  ignoreFieldNorm: true,
+};
+```
+
+Scale claim: "retrieval works as well with ten notes as ten thousand." But: Fuse.js threshold bugs appear >10k notes (scores of 0.59 leak through 0.2 threshold).
+
+### Foam: Graph Data Structures
+
+**Connection model (packages/foam-vscode/src/core/model/graph.ts):**
+```typescript
+export type Connection = {
+  source: URI;
+  target: URI;
+  link: ResourceLink;
+};
+
+export class FoamGraph {
+  public readonly links: Map<string, Connection[]> = new Map();       // outgoing
+  public readonly backlinks: Map<string, Connection[]> = new Map();   // incoming
+}
+```
+
+Full rebuild on every change: `clear() -> re-walk all resources`. Debounced at 500ms. O(N*L) where N=notes, L=avg links.
+
+**Workspace uses TrieMap** (from `mnemonist/trie-map`) for prefix-based lookup.
+
+### note-link-janitor: The Complete Algorithm (~200 lines)
+
+**Step 1:** Flat scan of `.md` files, parse with remark + remark-wiki-link.
+
+**Step 2:** Walk AST, find `wikiLink` nodes, capture containing block as context:
+```typescript
+visitParents<WikiLinkNode>(
+  tree, "wikiLink",
+  (node, ancestors) => {
+    const closestBlock = ancestors.reduceRight(
+      (result, needle) => result ?? (isBlockContent(needle) ? needle : null), null
+    );
+    links.push({ targetTitle: node.data.alias, context: closestBlock });
+  }
+);
+```
+
+**Step 3:** Build `Map<targetTitle, Map<sourceTitle, BlockContent[]>>`.
+
+**Step 4:** Compute PageRank (damping 0.85, convergence 0.000001).
+
+**Step 5:** Write `## Backlinks` section, sorted by PageRank:
+```markdown
+## Backlinks
+* [[Source Note Title]]
+	* The paragraph that contained the link
+```
+
+### Large Vault Patterns (nolebase, 484 files)
+
+```
+zh-CN/
+  生活/
+    租房/
+      租房流程.md
+      assets/          # co-located per topic
+    事务/
+      assets/
+  文档工程/
+  操作系统/
+    RedHat Enterprise Linux/
+    macOS/
+      assets/
+```
+
+Patterns: co-located assets per folder (not global), category folders (not flat), 2-3 level depth max, MOCs as manual indexes.

--- a/notes/research/knowledge-architecture-raw-research-part2.md
+++ b/notes/research/knowledge-architecture-raw-research-part2.md
@@ -1,0 +1,262 @@
+---
+title: "Extended Research: Knowledge Architecture — Raw Findings (Part 2)"
+description: "Internal reference: docs-as-code implementations, retrieval benchmarks, scale characteristics, and production hybrid systems"
+issue: "#18"
+epic: "#17"
+date: 2026-04-07
+type: research-note
+---
+
+# Extended Research: Raw Findings (Part 2 of 2)
+
+> Internal reference document. For the polished version, see [blog post parts 1-3](knowledge-architecture-comparison-part1.md).
+> See also: [Part 1 — Wiki Implementations and Zettelkasten](knowledge-architecture-raw-research-part1.md)
+
+## Docs-as-Code at Scale — Implementation Details
+
+### Kubernetes Docs (3000+ pages, Hugo)
+
+**Directory structure** under `content/en/docs/`:
+```
+docs/
+  _index.md
+  concepts/          # "What is X?"
+    architecture/
+    workloads/
+    services-networking/
+    storage/
+  tasks/             # "How to do X"
+    run-application/
+    configure-pod-container/
+  tutorials/         # End-to-end walkthroughs
+  reference/         # API specs, CLI, glossary
+  setup/
+  contribute/
+```
+
+**Content types enforced via archetypes.** Task archetype:
+```yaml
+---
+title: "{{ replace .Name \"-\" \" \" | title }}"
+content_type: task
+---
+<!-- overview -->
+## {{% heading "prerequisites" %}}
+{{< include "task-tutorial-prereqs.md" >}}
+<!-- steps -->
+<!-- discussion -->
+## {{% heading "whatsnext" %}}
+```
+
+HTML comments (`<!-- overview -->`, `<!-- body -->`, `<!-- steps -->`) act as section markers parsed by Hugo templates.
+
+**Cross-referencing mechanisms:**
+1. `{{< glossary_tooltip term_id="cluster" >}}` — looks up term_id in glossary folder, renders tooltip. Invalid term_id triggers `errorf` (build fails).
+2. `{{< include "task-tutorial-prereqs.md" >}}` — shared content partials
+3. `{{% code_sample file="application/deployment.yaml" %}}` — validated example file references
+
+**Navigation:** Weight-based ordering. Each `_index.md` has `weight: 40` in frontmatter. Hugo sorts by weight. `enableGitInfo = true` for lastmod from git.
+
+**Build performance:** `timeout = "180s"` in hugo.toml — 3000+ pages take ~3 min to build.
+
+### Docusaurus Sidebar Generation
+
+**Number prefix parsing** (from `numberPrefix.ts`):
+```
+01-intro.md      -> position: 1, slug: "intro"
+02-setup.md      -> position: 2, slug: "setup"
+003 - advanced   -> position: 3, slug: "advanced"
+```
+Ignores date-like (`2021-11-foo`) and version-like (`7.0-foo`) patterns.
+
+**Category metadata** via `_category_.json`:
+```json
+{
+  "label": "Guides",
+  "position": 2,
+  "link": { "type": "generated-index" }
+}
+```
+
+**Sidebar config** (`sidebars.ts`):
+```typescript
+const sidebars: SidebarsConfig = {
+  docs: [
+    'introduction',
+    {
+      type: 'category',
+      label: 'Guides',
+      link: { type: 'generated-index' },
+      items: ['guides/creating-pages', 'blog', ...]
+    }
+  ]
+};
+```
+
+**Versioning:** Physical copies per version — `versioned_docs/version-1.0.0/`. A project with 500 docs and 10 versions = 5000 files. Scales poorly.
+
+### Johnny Decimal Details
+
+**Core constraints:**
+- Areas: `X0-X9` (10 possible)
+- Categories: `XY` within area (10 per area)
+- IDs: `XY.ZZ` (100 per category)
+- Hard ceiling: 10 x 10 x 100 = 10,000 items
+
+**JDex index formats:**
+1. Single flat index file
+2. Nested folder mirrors
+3. Flat files where `N0.00` = area header, `AC.00` = category header
+
+**`jdlint` validations:** `CATEGORY_IN_WRONG_AREA`, `DUPLICATE_ID`, `ID_IN_WRONG_CATEGORY`. No overflow mechanism — create separate JD systems instead.
+
+### PARA at Scale
+
+**Hybrid PARA + Johnny Decimal** (Paratag variant):
+```
+10 - Projects/
+30 - Resources/
+  30.1 - Templates/
+  30.2 - Contacts/
+```
+
+**Pain point at scale:** Manual reclassification is the bottleneck past ~200 items. `para-shortcuts` Obsidian plugin automates moves. No automated classification tooling exists.
+
+## Retrieval Strategies — Technical Deep-Dive
+
+### Grep/ripgrep Performance
+
+**Benchmark numbers:**
+- 1.4GB monorepo (250K files): under 1 second
+- 240 log files: grep 4.2s, ripgrep 0.018s (233x speedup)
+- SIMD-optimized: 16-32 bytes per CPU cycle using finite automata
+- Crossover vs indexed search: ~500K-1M files (Cursor indexed search: 0.013s where ripgrep took 15s)
+
+**When grep beats embeddings:**
+- `ERROR_CODE_4532` vs `ERROR_CODE_4533` — near-identical vectors, trivially different strings
+- Regex over structured data: logs, JSON, config files, code
+- Zero setup, zero maintenance, zero cost
+
+### Vector Search Economics
+
+**Cost breakdown:**
+- Embedding: ~$0.10 per 1M tokens (ada-002)
+- Storage: ~1.5KB per vector (1536 dims)
+- Query latency: sub-millisecond with HNSW at 1M vectors
+- Managed: ~$70/month per 1M vectors (Pinecone)
+
+**OpenSearch 3.x hybrid:** BM25 + vector combined. Hybrid bulk scorer: 65% faster than separate execution. Additional 20% improvement in v3.3.
+
+### SPARQL Engine Benchmarks
+
+**Oxigraph (our engine):**
+- Tested on 35M triples (100K products dataset), 32GB machine
+- Python: ~20ms in-memory, ~38ms persistent, parsing ~20ms
+- "Suitable for small and medium-sized datasets" (ResearchGate evaluation)
+- Good for our current scale; revisit at millions of triples
+
+**Comparison landscape:**
+| Engine | Scale | Status |
+|--------|-------|--------|
+| Oxigraph | Small-medium (millions) | Active, Rust-based |
+| Blazegraph | Large (16B triples at Wikidata) | End-of-life, hitting limits |
+| QLever | Massive (1T+ claimed) | Academic, fastest on Wikidata queries |
+| Virtuoso | Enterprise (billions) | Mature, commercial |
+
+**Wikidata scaling crisis:** 16B triples, Blazegraph is EOL. Journal corruption under load. Split endpoint into two as emergency measure. Evaluating replacements.
+
+**When SPARQL wins over vector search:**
+- Multi-hop: "Papers citing Author X published in Venue Y"
+- Provenance: "Requirement -> test case -> coverage"
+- Aggregation: COUNT, FILTER, negation
+- Negation: "Entities WITHOUT relationship R" (impossible with similarity)
+
+### HybridRAG (NVIDIA/BlackRock) — Paper Details
+
+**Architecture:** Two parallel channels — VectorRAG (embed, cosine similarity) + GraphRAG (entity extraction, graph traversal). Results concatenated before generation.
+
+**Corpus:** Financial earnings call transcripts (Q&A format = natural ground truth).
+
+**Finding:** HybridRAG outperforms both individual approaches. Complementarity: vector captures semantic similarity, graph captures structured relational facts (e.g., "Company X acquired Company Y in Q3").
+
+**Limitation:** KG extraction expensive and error-prone on messy text. On opinion pieces/narrative without clear entities, graph channel adds cost without benefit.
+
+### Microsoft GraphRAG — Paper Details
+
+**Pipeline:**
+1. LLM extracts entities + relationships from text chunks
+2. Leiden community detection on resulting graph
+3. Hierarchical communities get LLM-generated summaries
+4. Queries answered by map-reducing over community summaries
+
+**Scale numbers (podcast corpus, 1M tokens):**
+- 8,564 nodes, 20,691 edges
+- Communities: 34 root (C0), 367 (C1), 969 (C2), 1,310 leaf (C3)
+
+**News corpus (1.7M tokens):**
+- 15,754 nodes, 19,520 edges
+- Communities: 55/555/1,797/2,142 across levels
+
+**vs Naive Vector RAG:**
+- Comprehensiveness win rate: 72-83% (p<0.001)
+- Diversity win rate: 75-82% (p<0.01)
+- Claims per answer: 31-34 vs 25-27
+- Token efficiency: root summaries used 2.6% of max context (9-43x reduction)
+
+**Cost:** 281 minutes indexing for 1M tokens with GPT-4-turbo on 16GB machine. Manageable at 1M; expensive at 100M tokens.
+
+**Key insight:** Naive RAG retrieves similar chunks. GraphRAG answers "global sensemaking" questions requiring synthesis across entire corpus.
+
+### Production Hybrid Systems
+
+**Glean (enterprise search):**
+Vector embeddings + BM25 + organizational knowledge graph (ownership, reporting, permissions). Graph provides permission-aware retrieval.
+
+**Neo4j + Pinecone integration:**
+1. Vector search returns top-k candidates
+2. Entity extraction on results
+3. Neo4j traversal enriches context
+4. Merged context feeds LLM
+
+**Reciprocal Rank Fusion (RRF):**
+`score = sum(1/(k + rank))` across all strategy ranked lists. Simple, parameter-light, consistently outperforms learned fusion.
+
+**Cost of 3-strategy system:**
+- Vector DB: ~$70/month per 1M vectors
+- Graph DB: ~$65/month for 200K nodes/400K relationships  
+- BM25 index: ~$50/month managed
+- Embedding: ~$0.10/1M tokens (one-time)
+- Graph extraction: periodic LLM re-runs
+
+## Scale Breaking Points Summary
+
+| Component | Works Until | Breaks At | Mitigation |
+|-----------|------------|-----------|------------|
+| Flat folder | ~200 files | 500+ files | Hierarchical subdirectories |
+| Single index.md | ~300 entries | 600+ lines | Hierarchical indexes (master -> topic -> sub-topic) |
+| Foam full graph rebuild | ~500 linked notes | 1000+ | Incremental updates |
+| Fuse.js fuzzy search | ~5K notes | 10K+ (threshold bugs) | Switch to dedicated search index |
+| Manual cross-refs | ~50 documents | 100+ | Auto-generated backlinks |
+| PARA reclassification | ~200 items | 500+ | Plugin-assisted or AI classification |
+| Context-window retrieval | ~500 pages | 1000+ | Add vector search tier |
+| Oxigraph SPARQL | ~35M triples | 100M+ | Migrate to QLever or Virtuoso |
+| GraphRAG indexing cost | ~2M tokens | 10M+ | Selective extraction, cheaper models |
+
+## Key References
+
+- [Karpathy llm-wiki gist](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f)
+- [ussumant/llm-wiki-compiler](https://github.com/ussumant/llm-wiki-compiler)
+- [atomicmemory/llm-wiki-compiler](https://github.com/atomicmemory/llm-wiki-compiler)
+- [xoai/sage-wiki](https://github.com/xoai/sage-wiki)
+- [Dendron](https://github.com/dendronhq/dendron)
+- [Foam](https://github.com/foambubble/foam)
+- [note-link-janitor](https://github.com/andymatuschak/note-link-janitor)
+- [Docusaurus](https://github.com/facebook/docusaurus)
+- [Kubernetes website](https://github.com/kubernetes/website)
+- [HybridRAG](https://arxiv.org/abs/2408.04948)
+- [Microsoft GraphRAG](https://arxiv.org/html/2404.16130v2)
+- [Oxigraph](https://github.com/oxigraph/oxigraph)
+- [QLever](https://github.com/ad-freiburg/qlever)
+- [OpenSearch hybrid search](https://opensearch.org/blog/opensearch-3-3-performance-innovations-for-ai-search-solutions/)
+- [Pinecone + Neo4j](https://www.pinecone.io/learn/vectors-and-graphs-better-together/)
+- [ripgrep benchmarks](https://burntsushi.net/ripgrep/)


### PR DESCRIPTION
## Summary
- 5 research documents (1138 lines) comparing 7 knowledge management approaches and 4 retrieval strategies
- Blog post (3 parts): Karpathy Wiki, Zettelkasten, PARA, Johnny Decimal, Digital Garden, Docs-as-Code, LLM-Native + grep/vector/SPARQL/hybrid benchmarks + our architecture proposal
- Extended internal research (2 parts): raw code snippets from real implementations, scale breaking points, production system analysis

## Test plan
- [x] All files under 600-line limit
- [x] Cross-links between parts are consistent
- [x] No secrets or credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)