### PR TITLE
WordPress publishing: research, script, and skill #39

### DIFF
--- a/.claude/skills/publish-article/SKILL.md
+++ b/.claude/skills/publish-article/SKILL.md
@@ -1,0 +1,46 @@
+# publish-article
+
+Publish a bilingual blog article to tellian.io via WordPress.com REST API v1.1.
+
+## Trigger
+
+/publish-article <slug>
+
+## Prerequisites
+
+- pandoc installed (sudo apt install pandoc)
+- WP_TOKEN set in .env (WordPress.com OAuth2 bearer token)
+- Article files exist: article-en.md and article-ru.md in the slug folder
+- Both files have YAML frontmatter with at least title field
+
+## Steps
+
+1. **Validate** -- check that article-en.md and article-ru.md exist in the slug folder
+2. **Preview** -- show the user the title, tags, categories extracted from frontmatter
+3. **Run script** -- execute scripts/publish-to-wp.sh {slug} (publishes as draft by default)
+4. **Verify** -- check the response for success, show the WordPress URL
+5. **Update status** -- update frontmatter status: published and wordpress_url in both article files
+6. **Copy to published** -- copy the slug folder to the published directory
+7. **Report** -- show the published URL to the user
+
+## Publish as live (not draft)
+
+Add --publish flag: scripts/publish-to-wp.sh {slug} --publish
+
+Only do this after the user explicitly confirms.
+
+## Token setup (one-time)
+
+1. Go to https://developer.wordpress.com/apps/new and register an app
+2. Set redirect URL to https://tellian.io/
+3. Note the client_id and client_secret
+4. Get token:
+   ```
+   curl -X POST https://public-api.wordpress.com/oauth2/token \
+     -d "client_id=YOUR_CLIENT_ID" \
+     -d "client_secret=YOUR_CLIENT_SECRET" \
+     -d "grant_type=password" \
+     -d "username=YOUR_WPCOM_USERNAME" \
+     -d "password=YOUR_APP_PASSWORD"
+   ```
+5. Add to .env: WP_TOKEN=the_returned_access_token

--- a/notes/research/wordpress-publishing-research.md
+++ b/notes/research/wordpress-publishing-research.md
@@ -20,7 +20,7 @@ Date: 2026-04-07
 
 ### Multilingual approach
 
-The site uses a **manual bilingual structure within single posts** — not a plugin:
+The site uses a **manual bilingual structure within single posts** -- not a plugin:
 
 - Each post contains both EN and RU content in one document
 - Language switcher at top: `<a href="#en">English</a> | <a href="#ru">Русский</a>`
@@ -38,15 +38,15 @@ This means publishing automation must construct the combined bilingual HTML.
 
 ## 2. API Availability
 
-### WordPress.org REST API (`/wp-json/`)
+### WordPress.org REST API (/wp-json/)
 
-**Not available.** Both `/wp-json/wp/v2/` and `/wp-json/wp/v2/posts` return 404. WordPress.com does not expose the self-hosted REST API endpoints by default.
+**Not available.** Both /wp-json/wp/v2/ and /wp-json/wp/v2/posts return 404. WordPress.com does not expose the self-hosted REST API endpoints by default.
 
 ### WordPress.com REST API v1.1
 
-**Available and working.** Endpoint: `https://public-api.wordpress.com/rest/v1.1/sites/tellian.io/`
+**Available and working.** Endpoint: https://public-api.wordpress.com/rest/v1.1/sites/tellian.io/
 
-- GET posts works without auth: `GET /rest/v1.1/sites/tellian.io/posts/`
+- GET posts works without auth
 - POST (create) requires OAuth2 bearer token
 - Full post objects returned with title, content, categories, tags, slug, status
 
@@ -56,53 +56,43 @@ WordPress.com uses OAuth2:
 
 1. Register app at https://developer.wordpress.com/apps/new
 2. Get client_id + client_secret
-3. Exchange credentials for bearer token via `grant_type=password` flow (no browser needed)
-4. Use `Authorization: Bearer TOKEN` for all write requests
+3. Exchange credentials for bearer token via grant_type=password flow (no browser needed)
+4. Use Authorization: Bearer TOKEN for all write requests
 
-Create post endpoint: `POST https://public-api.wordpress.com/rest/v1.1/sites/tellian.io/posts/new`
+Create post endpoint: POST https://public-api.wordpress.com/rest/v1.1/sites/tellian.io/posts/new
 
 ## 3. MCP Server Options
 
 ### Option A: WordPress.com built-in MCP
 
-- URL: `https://public-api.wordpress.com/wpcom/v2/mcp/v1`
-- Uses OAuth 2.1 with PKCE
+- URL: https://public-api.wordpress.com/wpcom/v2/mcp/v1
 - Official WordPress.com + Anthropic partnership (Feb 2026)
-- **Limitation:** Currently read-only. Cannot create, delete, or modify content. Designed for analytics, content analysis, SEO audits.
-- **Verdict:** Not suitable for publishing. Read-only.
+- **Limitation:** Currently read-only. Cannot create, delete, or modify content.
+- **Verdict:** Not suitable for publishing.
 
 ### Option B: AI Engine plugin (Meow Apps)
 
 - Requires installing the AI Engine WordPress plugin
 - Provides 87 MCP tools including post management
-- Setup: `claude mcp add wp-site https://site.com/wp-json/mcp/v1/http --transport http --header "Authorization: Bearer TOKEN"`
-- **Limitation:** Requires plugin installation. WordPress.com Business plan or higher needed to install plugins. May not be available on current plan.
+- **Limitation:** WordPress.com Business plan ($33/mo) or higher needed to install plugins.
 - **Verdict:** Viable only if plugin installation is possible on the current plan.
 
 ### Option C: claudeus-wp-mcp (GitHub)
 
 - 145 tools, self-hosted MCP server
-- Requires self-hosted WordPress (not WordPress.com)
 - **Verdict:** Not compatible with WordPress.com hosting.
 
 ### Option D: Royal MCP plugin
 
 - Security-focused MCP plugin
-- Same limitation as Option B — requires plugin installation
-- **Verdict:** Same constraint as AI Engine.
+- **Verdict:** Same constraint as AI Engine -- requires plugin installation.
 
 ## 4. Publishing Options Evaluation
 
 ### Option 1: WordPress.com REST API v1.1 + shell script (RECOMMENDED)
 
-**How it works:**
-1. Markdown articles in `publications/drafts/{slug}/` (already set up per #36)
-2. Convert MD to HTML using pandoc
-3. Wrap EN + RU HTML in bilingual div structure matching existing posts
-4. POST to WordPress.com REST API v1.1 with OAuth2 token
-5. Update frontmatter with wordpress_url after publishing
-
 **Pros:**
+
 - Works with WordPress.com hosted sites directly
 - No plugins needed
 - Full control over HTML output
@@ -111,90 +101,47 @@ Create post endpoint: `POST https://public-api.wordpress.com/rest/v1.1/sites/tel
 - Can be wrapped in a Claude Code skill
 
 **Cons:**
+
 - One-time OAuth2 app registration needed
-- Token management (store in .mcp.json or env var)
+- Token management (store in .env)
 - Must construct bilingual HTML wrapper manually
 
-**Setup complexity:** Low-medium. Register app, get token, write publish script.
+**Setup complexity:** Low-medium.
 **Maintenance:** Low. Token refresh if expired.
 
 ### Option 2: WordPress.com MCP (built-in)
 
-**Verdict:** Not viable — read-only, cannot create posts.
+**Verdict:** Not viable -- read-only, cannot create posts.
 
 ### Option 3: AI Engine MCP plugin
 
-**Pros:**
-- Rich tool set (87 functions)
-- Native MCP integration with Claude Code
-- Polylang support (11 functions) — though site doesn't use Polylang
-
-**Cons:**
-- Requires WordPress.com Business plan ($33/mo) to install plugins
-- Plugin dependency — if AI Engine breaks, publishing breaks
-- Overkill for publishing articles (87 tools when we need ~3)
-
-**Setup complexity:** Medium. Upgrade plan + install plugin + configure MCP.
-**Maintenance:** Medium. Plugin updates, compatibility.
+**Verdict:** Requires WordPress.com Business plan ($33/mo). Overkill.
 
 ### Option 4: wp-cli via SSH
 
-**Verdict:** Not available on WordPress.com hosting. Only on self-hosted.
+**Verdict:** Not available on WordPress.com hosting.
 
-### Option 5: Manual copy-paste with documented process
+### Option 5: Manual copy-paste
 
-**Pros:**
-- Zero setup
-- Works immediately
-- Full visual control
-
-**Cons:**
-- Manual effort each time
-- No automation possible
-- Error-prone for bilingual HTML structure
-
-**Setup complexity:** None.
-**Maintenance:** High (human effort per post).
+**Pros:** Zero setup. **Cons:** Manual effort, error-prone.
 
 ## 5. Markdown to HTML Conversion
 
 ### Recommended: pandoc
 
-- `pandoc -f markdown -t html article.md`
-- Handles code blocks, tables, headers, links, images
-- Available on most Linux systems
-- Can be called from shell scripts
-
-### Alternatives
-
-- **marked** (Node.js) — good if you prefer JS toolchain
-- **showdown** (JS) — browser-compatible, less feature-rich
-- **python-markdown** — if Python preferred
+Install: sudo apt install pandoc
+Usage: pandoc -f markdown -t html article.md
 
 ### Special handling needed
 
-- Code blocks: pandoc produces proper `<pre><code>` blocks
-- Images: must be uploaded to WordPress media library first, then referenced by URL
-- Tables: pandoc produces HTML tables, which Gutenberg handles
-- The bilingual wrapper divs must be added after conversion
+- Images: upload to WordPress media library first, then reference by URL
+- Bilingual wrapper divs must be added after conversion
 
 ## 6. Recommendation
 
 **Use Option 1: WordPress.com REST API v1.1 + publish script.**
 
-### Implementation plan
-
-1. Register a WordPress.com OAuth2 app (one-time, manual)
-2. Get bearer token via password grant (one-time, store in `.env` or `.mcp.json`)
-3. Create `scripts/publish-to-wp.sh`:
-   - Reads article-en.md and article-ru.md from a publications/drafts/{slug}/ folder
-   - Converts each to HTML via pandoc
-   - Wraps in bilingual div structure
-   - Extracts frontmatter (title, tags, categories, slug)
-   - POSTs to WordPress.com API
-   - Returns the published URL
-4. Create a Claude Code skill `publish-article` that orchestrates the above
-5. Update publication.md template with publishing instructions
+Script at scripts/publish-to-wp.sh, Claude Code skill publish-article orchestrates.
 
 ### Bilingual HTML template
 
@@ -208,17 +155,4 @@ Create post endpoint: `POST https://public-api.wordpress.com/rest/v1.1/sites/tel
 <div id="ru" class="wp-block-group lang-block">
 {russian_html}
 </div>
-```
-
-### API call structure
-
-```bash
-curl -X POST \
-  "https://public-api.wordpress.com/rest/v1.1/sites/tellian.io/posts/new" \
-  -H "Authorization: Bearer $WP_TOKEN" \
-  -d "title=$TITLE" \
-  -d "content=$BILINGUAL_HTML" \
-  -d "status=draft" \
-  -d "tags=$TAGS" \
-  -d "categories=$CATEGORIES"
 ```

--- a/scripts/publish-to-wp.sh
+++ b/scripts/publish-to-wp.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# publish-to-wp.sh — Publish a bilingual blog article to tellian.io
+# via WordPress.com REST API v1.1
+# Usage: ./scripts/publish-to-wp.sh <slug> [--publish]
+# Requires: pandoc, curl, WP_TOKEN env var (or .env file)
+# Issue: #39
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SITE="tellian.io"
+API_BASE="https://public-api.wordpress.com/rest/v1.1/sites/${SITE}"
+
+# --- Load token ---
+if [ -z "${WP_TOKEN:-}" ]; then
+  if [ -f "$REPO_ROOT/.env" ]; then
+    # shellcheck source=/dev/null
+    source "$REPO_ROOT/.env"
+  fi
+fi
+
+if [ -z "${WP_TOKEN:-}" ]; then
+  echo "ERROR: WP_TOKEN not set. Export it or add to .env file." >&2
+  echo "  Get a token: https://developer.wordpress.com/docs/api/getting-started/" >&2
+  exit 1
+fi
+
+# --- Parse args ---
+if [ $# -lt 1 ]; then
+  echo "Usage: $0 <slug> [--publish]" >&2
+  echo "  slug      — folder name under publications drafts directory" >&2
+  echo "  --publish — set status to 'publish' (default: 'draft')" >&2
+  exit 1
+fi
+
+SLUG="$1"
+STATUS="draft"
+if [ "${2:-}" = "--publish" ]; then
+  STATUS="publish"
+fi
+
+# Try multiple possible draft locations
+DRAFT_DIR=""
+for candidate in \
+  "$REPO_ROOT/publications/blog/drafts/$SLUG" \
+  "$REPO_ROOT/publications/drafts/$SLUG" \
+  "$REPO_ROOT/blog/drafts/$SLUG"; do
+  if [ -d "$candidate" ]; then
+    DRAFT_DIR="$candidate"
+    break
+  fi
+done
+
+if [ -z "$DRAFT_DIR" ]; then
+  echo "ERROR: Draft directory not found for slug: $SLUG" >&2
+  echo "  Looked in: publications/blog/drafts/, publications/drafts/, blog/drafts/" >&2
+  exit 1
+fi
+
+echo "Using draft directory: $DRAFT_DIR"
+
+# --- Check for article files ---
+EN_FILE="$DRAFT_DIR/article-en.md"
+RU_FILE="$DRAFT_DIR/article-ru.md"
+
+if [ ! -f "$EN_FILE" ]; then
+  echo "ERROR: English article not found: $EN_FILE" >&2
+  exit 1
+fi
+
+if [ ! -f "$RU_FILE" ]; then
+  echo "ERROR: Russian article not found: $RU_FILE" >&2
+  exit 1
+fi
+
+# --- Check pandoc ---
+if ! command -v pandoc &>/dev/null; then
+  echo "ERROR: pandoc not installed. Install with: sudo apt install pandoc" >&2
+  exit 1
+fi
+
+# --- Extract frontmatter from EN file (primary) ---
+extract_frontmatter() {
+  local file="$1"
+  local key="$2"
+  sed -n '/^---$/,/^---$/p' "$file" \
+    | grep "^${key}:" | head -1 \
+    | sed "s/^${key}:[[:space:]]*//" \
+    | sed 's/^"\(.*\)"$/\1/' \
+    | sed "s/^'\(.*\)'$/\1/"
+}
+
+TITLE=$(extract_frontmatter "$EN_FILE" "title")
+TAGS_RAW=$(extract_frontmatter "$EN_FILE" "tags")
+CATEGORIES_RAW=$(extract_frontmatter "$EN_FILE" "categories")
+
+if [ -z "$TITLE" ]; then
+  TITLE=$(grep -m1 '^# ' "$EN_FILE" | sed 's/^# //')
+fi
+
+if [ -z "$TITLE" ]; then
+  echo "ERROR: Could not extract title from $EN_FILE" >&2
+  exit 1
+fi
+
+echo "Title: $TITLE"
+echo "Slug: $SLUG"
+echo "Status: $STATUS"
+
+# --- Convert MD to HTML ---
+strip_frontmatter() {
+  local file="$1"
+  if head -1 "$file" | grep -q '^---$'; then
+    tail -n +2 "$file" | sed '1,/^---$/d' | sed '1{/^$/d}'
+  else
+    cat "$file"
+  fi
+}
+
+EN_HTML=$(strip_frontmatter "$EN_FILE" | pandoc -f markdown -t html --no-highlight)
+RU_HTML=$(strip_frontmatter "$RU_FILE" | pandoc -f markdown -t html --no-highlight)
+
+# --- Build bilingual content ---
+CONTENT=$(cat <<HTMLEOF
+<!-- wp:paragraph -->
+<p><a href="#en">English</a> | <a href="#ru">Русский</a></p>
+<!-- /wp:paragraph -->
+
+<!-- wp:separator -->
+<hr class="wp-block-separator"/>
+<!-- /wp:separator -->
+
+<!-- wp:group {"className":"lang-block default"} -->
+<div id="en" class="wp-block-group lang-block default">
+${EN_HTML}
+</div>
+<!-- /wp:group -->
+
+<!-- wp:separator -->
+<hr class="wp-block-separator"/>
+<!-- /wp:separator -->
+
+<!-- wp:group {"className":"lang-block"} -->
+<div id="ru" class="wp-block-group lang-block">
+${RU_HTML}
+</div>
+<!-- /wp:group -->
+HTMLEOF
+)
+
+# --- Clean tags (strip YAML array syntax) ---
+clean_list() {
+  echo "$1" | tr -d '[]' \
+    | sed 's/,/\n/g' \
+    | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' \
+    | grep -v '^$' \
+    | paste -sd',' -
+}
+
+TAGS=""
+if [ -n "${TAGS_RAW:-}" ]; then
+  TAGS=$(clean_list "$TAGS_RAW")
+  echo "Tags: $TAGS"
+fi
+
+CATEGORIES=""
+if [ -n "${CATEGORIES_RAW:-}" ]; then
+  CATEGORIES=$(clean_list "$CATEGORIES_RAW")
+  echo "Categories: $CATEGORIES"
+fi
+
+# --- Publish via API ---
+echo ""
+echo "Publishing to ${SITE}..."
+
+RESPONSE=$(curl -s -X POST "${API_BASE}/posts/new" \
+  -H "Authorization: Bearer ${WP_TOKEN}" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  --data-urlencode "title=${TITLE}" \
+  --data-urlencode "slug=${SLUG}" \
+  --data-urlencode "content=${CONTENT}" \
+  --data-urlencode "status=${STATUS}" \
+  --data-urlencode "tags=${TAGS}" \
+  --data-urlencode "categories=${CATEGORIES}" \
+  --data-urlencode "format=standard")
+
+# --- Check response ---
+POST_URL=$(echo "$RESPONSE" | python3 -c \
+  "import sys,json; d=json.load(sys.stdin); print(d.get('URL',''))" \
+  2>/dev/null || true)
+POST_ID=$(echo "$RESPONSE" | python3 -c \
+  "import sys,json; d=json.load(sys.stdin); print(d.get('ID',''))" \
+  2>/dev/null || true)
+ERROR=$(echo "$RESPONSE" | python3 -c \
+  "import sys,json; d=json.load(sys.stdin); print(d.get('error',''))" \
+  2>/dev/null || true)
+
+if [ -n "$ERROR" ] && [ "$ERROR" != "" ] && [ "$ERROR" != "None" ]; then
+  ERROR_MSG=$(echo "$RESPONSE" | python3 -c \
+    "import sys,json; d=json.load(sys.stdin); print(d.get('message','Unknown error'))" \
+    2>/dev/null || true)
+  echo "ERROR: API returned error: $ERROR — $ERROR_MSG" >&2
+  echo "Full response:" >&2
+  echo "$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "$RESPONSE" >&2
+  exit 1
+fi
+
+if [ -n "$POST_URL" ] && [ "$POST_URL" != "" ] && [ "$POST_URL" != "None" ]; then
+  echo ""
+  echo "SUCCESS!"
+  echo "  Post ID: $POST_ID"
+  echo "  URL: $POST_URL"
+  echo "  Status: $STATUS"
+
+  # Update frontmatter in both files with wordpress_url
+  sed -i "s|^wordpress_url:.*|wordpress_url: \"${POST_URL}\"|" "$EN_FILE"
+  if [ -f "$RU_FILE" ]; then
+    sed -i "s|^wordpress_url:.*|wordpress_url: \"${POST_URL}\"|" "$RU_FILE"
+  fi
+
+  echo "  Updated frontmatter in article files with wordpress_url"
+else
+  echo "WARNING: Could not extract URL from response. Full response:" >&2
+  echo "$RESPONSE" | python3 -m json.tool 2>/dev/null || echo "$RESPONSE" >&2
+fi


### PR DESCRIPTION
## Summary

- Research tellian.io WordPress setup: WordPress.com hosted, TwentySixteen theme, manual bilingual posts (EN/RU in single post with `div.lang-block` sections)
- WordPress.com REST API v1.1 is available and working; standard `/wp-json/` returns 404
- Evaluated 5 publishing options; recommend REST API v1.1 + OAuth2 + shell script
- WordPress.com built-in MCP is read-only (cannot create posts); plugin-based MCP requires Business plan upgrade ($33/mo)
- Created `scripts/publish-to-wp.sh`: converts MD to HTML via pandoc, wraps in bilingual structure, POSTs to API
- Created `/publish-article` skill for Claude Code orchestration
- Added decision entry to `notes/decisions.md`

## One-time setup needed (manual)

1. Register OAuth2 app at https://developer.wordpress.com/apps/new
2. Get bearer token via `grant_type=password` flow
3. Add `WP_TOKEN=...` to `.env`
4. Install pandoc: `sudo apt install pandoc`

## Test plan

- [ ] Register WordPress.com OAuth2 app and obtain token
- [ ] Create a test article in drafts folder with article-en.md and article-ru.md
- [ ] Run `scripts/publish-to-wp.sh test-slug` and verify draft appears on tellian.io
- [ ] Verify bilingual HTML structure matches existing posts
- [ ] Test `--publish` flag for direct publishing

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)