### PR TITLE
Fix: YAML-frontmatter для 4 legacy-агентов (#88)

### DIFF
--- a/.claude/agents/course-curator.md
+++ b/.claude/agents/course-curator.md
@@ -1,3 +1,8 @@
+---
+name: course-curator
+description: Связывает нормативные документы, лекции, материалы и задания — строит/обновляет связи в онтологии и манифестах. Применяй при cross-linking учебных артефактов (covers/cites/depends_on).
+---
+
 # Course Curator Agent
 
 You are a subagent responsible for maintaining the knowledge graph that links normative documents, lectures, topics, requirements, and materials in the AI-usage-lessons project. You use the ontology (Oxigraph via open-ontologies MCP) and local RAG for semantic search.

--- a/.claude/agents/doc-editor.md
+++ b/.claude/agents/doc-editor.md
@@ -1,3 +1,8 @@
+---
+name: doc-editor
+description: Редактирует Google Docs через workspace-mcp (правки текста, форматирование, структура). Применяй когда нужно изменить содержимое Google-документа, которым владеет курс.
+---
+
 # Document Editor Agent
 
 You are a subagent responsible for editing Google Docs content in the AI-usage-lessons project. You make precise, targeted edits to documents while preserving structure and formatting.

--- a/.claude/agents/issue-manager.md
+++ b/.claude/agents/issue-manager.md
@@ -1,3 +1,8 @@
+---
+name: issue-manager
+description: Создаёт и триажит GitHub Issues, ведёт очередь изменений. Применяй для заведения задач из изменений, триажа и связки issue ↔ артефакты.
+---
+
 # Issue Manager Agent
 
 You are a subagent responsible for creating, triaging, and managing GitHub Issues in the AI-usage-lessons project. You ensure every piece of work is tracked, labeled, and linked to affected entities.

--- a/.claude/agents/librarian.md
+++ b/.claude/agents/librarian.md
@@ -1,3 +1,8 @@
+---
+name: librarian
+description: Поиск, синхронизация, экспорт и индексация документов проекта (Google Drive → локальный catalog). Применяй для sync-library, экспорта Docs/Sheets/Slides/PDF, обновления RAG-индекса и манифестов catalog/manifests/*.yaml.
+---
+
 # Librarian Agent
 
 You are a subagent responsible for searching, exporting, and indexing documents in the AI-usage-lessons project. You work with Google Drive as the source and local catalog as the target.


### PR DESCRIPTION
## Что
Добавлен YAML-frontmatter (`name` + `description`) в начало 4 файлов агентов, написанных в старом формате (2026-03-31):
- `.claude/agents/librarian.md`
- `.claude/agents/course-curator.md`
- `.claude/agents/doc-editor.md`
- `.claude/agents/issue-manager.md`

## Зачем
Claude Code регистрирует субагента как `subagent_type` только при наличии frontmatter. Без него эти 4 агента «not found», хотя CLAUDE.md § Working Conventions ссылается на них как на рабочие. Делегирование на них было невозможно.

## Проверка
Тело файлов не тронуто — только добавлен frontmatter сверху. Образец — `book-editor.md`/`fact-checker.md`. **Требуется рестарт Claude Code** для регистрации (как с MCP).

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)