### PR TITLE
Манифест: lec-03 + lec-06 → produced (хвост #97)

### DIFF
--- a/catalog/manifests/lectures.yaml
+++ b/catalog/manifests/lectures.yaml
@@ -44,9 +44,9 @@ lectures:
     module: 1
     learning_outcomes: [LO7, LO4]
     repo_dir: lec-03
-    status: in_production
+    status: produced
     issue: 87
-    updated_at: "2026-05-16"
+    updated_at: "2026-05-17"
 
   - number: 4
     title: "AI в разработке программного обеспечения"
@@ -69,7 +69,7 @@ lectures:
     module: 1
     learning_outcomes: [LO1, LO2, LO7]
     repo_dir: lec-06
-    status: in_production
+    status: produced
     issue: 101
     updated_at: "2026-05-17"
 


### PR DESCRIPTION
Актуализация `catalog/manifests/lectures.yaml` под фактическое состояние:
- **lec-03** `in_production`→`produced` (PR #91 MERGED, issue #87)
- **lec-06** `in_production`→`produced` (PR #102 MERGED, issue #101)

lec-07 уже produced. Хвост по issue #97 «Актуализация артефактов под актуальный РПД». YAML провалидирован.

🤖 Generated with [Claude Code](https://claude.com/claude-code)