### PR TITLE
Chapter ≥30k слов для L4+ лекций — базовое правило ENFORCED

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,46 @@ Issues and tasks are tracked at: `https://github.com/orgs/tellina-study/projects
 
 ---
 
+## Chapter Depth Baseline (ENFORCED — фундаментальное)
+
+**Правило.** `library/lectures/lec-NN/chapter.md` для всех **L4–L17 лекций — минимум 30 000 слов** (target 30k ±5% = 28 500–31 500). Это **базовый референс**, не конспект 75-мин лекции; chapter — это **полный методический референс уровня академического textbook chapter**, source-of-truth для slides+speech derivation + Q&A backup + self-study deep-dive материал.
+
+**Применимость:**
+- **L1–L3 (introductory):** owner waiver доступен (как для AI-Failure rule). Без записанного waiver — правило применяется. Реестр waivers в `tools/lecture-production/README.md` §3.6.
+- **L4–L17:** ≥30 000 слов **mandatory**, waiver недоступен.
+
+**Multi-part split:** если chapter >600 строк, обязательное разбиение на части:
+- `chapter.md` — частина 1 + frontmatter с `parts: N`, `length_words: ~XXk`
+- `chapter-part2.md` — часть 2
+- `chapter-part3.md` — часть 3 (если нужно)
+- Cross-link через TOC в chapter.md
+
+Каждый файл ≤600 строк per CLAUDE.md «Document Size Limit».
+
+**Что НЕ засчитывается в 30k:**
+- Frontmatter YAML
+- Markdown headings без содержания
+- TOC / list-only sections
+- Источники / bibliography (это отдельно)
+
+**Counter-check (mandatory):** chapter <30k для L4+ → **REVISE verdict**, не «короткий — норм». Это структурный gap, не polish. `methodology-critic` Phase 3 проверяет word count + reading-as-textbook-chapter quality.
+
+**Why ENFORCED:**
+- 30k = textbook chapter depth (соответствует уровню expectation для серьёзного университетского курса).
+- 75-мин лекция проходит ≤40% содержания chapter'а — остальное Q&A backup + self-study + источник для derivation slides/speech.
+- Лекции 4-5 = 8.7-8.9k (рано) — owner explicit «недостаточно глубоко».
+- Лекция 11 v2 = 13.4k — owner explicit «должен быть как L8/L9, минимум 30k для всех». Решение 2026-05-21, issue #128.
+
+**Enforcement points:**
+- Phase 1 plan-checklist выделяет 30k target в plan v1.
+- Phase 2 chapter draft — book-editor target 30k.
+- Phase 3 methodology-critic проверяет word count: <30k → REVISE; <28.5k для L4+ → P0 BLOCKING.
+- Pre-USER-GATE A — word count check в orchestrator walkthrough.
+
+**Связано:** [[feedback_chapter_depth]] (memory rule).
+
+---
+
 ## Orchestration Rule (ENFORCED)
 
 Claude Code acts as **planner and orchestrator only**. It MUST NOT make implementation changes directly. ALL implementation work MUST be delegated to subagents (Agent tool with appropriate prompts).
@@ -330,7 +370,7 @@ Every time a new finding, gotcha, or best practice is discovered during work, it
 **Lecture production (multi-artifact: chapter + slides + speech):**
 | Agent | Producer/Critic | Responsibility |
 |-------|---|---------------|
-| `book-editor` | Producer | Пишет/правит главу методички (`chapter.md`, ~10k слов, academic) |
+| `book-editor` | Producer | Пишет/правит главу методички (`chapter.md`, ≥30k слов для L4+, см. § Chapter Depth Baseline) |
 | `presentation-designer` | Producer | Визуальный дизайнер deck'а — рендер через PowerPoint MCP с visual-loop, Ocean palette + Anthropic anti-patterns |
 | `speech-writer` | Producer | Пишет речь лектора (`speech.md`, ~5k слов, conversational) |
 | `methodology-critic` | Critic | Pedagogical depth, LO coverage, sequence, assertion-evidence (применяется к chapter, plan, slides, speech) |
@@ -343,7 +383,7 @@ Every time a new finding, gotcha, or best practice is discovered during work, it
 ### Lecture Production Pipeline (ENFORCED, multi-artifact)
 
 **Canonical doc:** `tools/lecture-production/README.md` — полный 10-фазный pipeline для production лекции с **3 финальными артефактами**:
-1. `library/lectures/lec-NN/chapter.md` — глава методички (~10k слов, **source of truth**, academic).
+1. `library/lectures/lec-NN/chapter.md` — глава методички (**≥30k слов** для L4+ per § Chapter Depth Baseline, **source of truth**, academic textbook chapter; multi-part split при >600 строк).
 2. `library/lectures/lec-NN/rendered/lec-NN.pptx` — презентация со speaker notes (derived from chapter).
 3. `library/lectures/lec-NN/speech.md` — речь лектора (~5k слов, conversational; derived from chapter+slides).
 

--- a/tools/lecture-production/README.md
+++ b/tools/lecture-production/README.md
@@ -10,7 +10,9 @@
 
 ```
 library/lectures/lec-NN/
-  chapter.md              ← глава методички ~8-12k слов (academic)         [PRIMARY = source of truth]
+  chapter.md              ← глава методички ≥30k слов для L4+ (academic)   [PRIMARY = source of truth]
+  chapter-part2.md        ← multi-part split при >600 строк (CLAUDE.md doc-size-limit)
+  chapter-part3.md        ← опционально при >1200 строк суммарно
   rendered/lec-NN.pptx    ← презентация со speaker notes для студентов     [DERIVED from chapter]
   speech.md               ← речь лектора ~4-6k слов (conversational)        [DERIVED from chapter + slides]
 ```
@@ -323,11 +325,16 @@ Producer-агенты (book-editor / presentation-designer / speech-writer) ча
 
 | Артефакт | Длина | Pacing |
 |---|---|---|
-| `chapter.md` | 8-12k слов (~30-50 страниц A4) | Self-study, ~30-60 мин чтения |
+| `chapter.md` | **≥30 000 слов для L4+** (target 30k ±5% = 28 500–31 500), L1–L3 8-12k без waiver | Textbook chapter depth + Q&A backup + self-study reference; ~2-3 ч глубокого чтения |
 | `slides/*.md` | ~150-300 слов на slide × 25-30 slides ≈ 5-8k слов суммарно | Visible content + speaker notes |
 | `speech.md` | 4-6k слов (≈70-80 wpm × 75 мин) | Сliceful pacing, паузы, переходы |
 
-**Если chapter < 5k или > 15k — red flag** (либо мало материала для лекции, либо overload).
+**Chapter Depth Baseline (ENFORCED — см. `CLAUDE.md` § «Chapter Depth Baseline»):**
+- L4–L17: **≥30 000 слов** mandatory, waiver недоступен; <28 500 слов → REVISE (структурный gap, не polish).
+- L1–L3: 8-12k acceptable; ≥30k если owner explicit instruction.
+- **Multi-part split mandatory при >600 строк per file** (CLAUDE.md «Document Size Limit»): `chapter.md` + `chapter-part2.md` + `chapter-part3.md`, cross-link через TOC.
+
+**Что НЕ засчитывается в 30k:** frontmatter YAML, heading-only sections, TOC, Источники / bibliography (это отдельно).
 
 ---
 


### PR DESCRIPTION
## Summary
- Owner explicit override (2026-05-21, Лекция 11 production): **chapter ≥30 000 слов mandatory для всех L4+ лекций**, не текущий 8-12k и не 20-26k для Lec-10.
- Новая ENFORCED секция в CLAUDE.md «Chapter Depth Baseline», обновление tools/lecture-production/README.md §6.
- Closes #128.

## Изменения

### CLAUDE.md
- Новая секция «Chapter Depth Baseline (ENFORCED — фундаментальное)»:
  - L4–L17: ≥30k слов mandatory (target 30k ±5% = 28 500–31 500).
  - L1–L3: 8-12k acceptable, owner waiver доступен.
  - Multi-part split при >600 строк per file (CLAUDE.md doc-size-limit).
  - Counter-check: <28.5k для L4+ → REVISE (структурный gap), не polish.
  - Что НЕ засчитывается: frontmatter, headings, TOC, источники.
  - Enforcement points: Phase 1/2/3 + Pre-USER-GATE A.
- Обновлены 2 inline-описания `chapter.md` (table + numbered list).

### tools/lecture-production/README.md
- §6 «Размер artifacts»: chapter range 8-12k → ≥30k для L4+.
- §2 финальные артефакты: chapter-part2/3 при multi-part split.
- Red-flag «>15k» для L4+ снят (теперь это норма).

### Memory
- `feedback_chapter_depth.md` обновлён с 20-26k → ≥30k baseline.

## Эволюция правила
- L1-L3 (introductory): 8-12k.
- L4-L5 (early): 8.7-8.9k — owner explicit «недостаточно глубоко».
- L6-L7: 12.7-12.9k (после feedback_chapter_depth первой версии).
- L8-L9: 15.9-17k (тренд глубже).
- L10 plan: 20-26k (owner explicit «как L4-L5»).
- **L11 (текущая, 2026-05-21):** owner explicit override — 30k минимум для всех L4+.

## Test plan
- [ ] L11 chapter v3 expansion (29 822 слова, 99.4% от 30k) служит первым acceptance test.
- [ ] При Phase 4d (L11 finalize) — `methodology-critic` проверяет word count check работает.
- [ ] Pre-USER-GATE A walkthrough на L11 включает word count verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)