### PR TITLE
[Revert] Remove disposable AC3 post-deploy verification file

### DIFF
--- a/AC3_VERIFY_DISPOSABLE.md
+++ b/AC3_VERIFY_DISPOSABLE.md
@@ -1,7 +1,0 @@
-# AC3 Disposable Verification File
-
-This file exists solely to verify harness-control#665 / PR #667 post-deploy AC3
-(commit 890564e is live). It is meant to be deleted after the verification PR
-is merged/closed.
-
-Created: 2026-08-05


### PR DESCRIPTION
## Purpose
Reverts the disposable marker file `AC3_VERIFY_DISPOSABLE.md` that was merged via PR #150
as part of harness-control#665 / PR #667 post-deploy AC3 confirmation.

That file had no functional purpose — it existed only to verify `gh`/`git` CLI wiring
end-to-end after deploy 890564e went live. This PR removes it from the real repo so it
doesn't linger as clutter.